### PR TITLE
Resolved OLED artifact when RSSI < 50

### DIFF
--- a/ESP32LapTimer/OLED.ino
+++ b/ESP32LapTimer/OLED.ino
@@ -79,7 +79,11 @@ void oledUpdate(void)
     display.setTextAlignment(TEXT_ALIGN_LEFT);
     for (int i = 0; i < NumRecievers; i++) {
       display.drawString(0, 9 + i * 9, getBandLabel(RXBand[i]) + String(RXChannel[i] + 1) + ", " + String(ADCvalues[i] / 12));
-      display.drawProgressBar(40, 10 + i * 9, 127 - 42, 8, map(ADCvalues[i], 600, 3500, 0, 85));
+      if (ADCvalues[i] < 600) {
+        display.drawProgressBar(40, 10 + i * 9, 127 - 42, 8, map(600, 600, 3500, 0, 85));
+      } else {
+        display.drawProgressBar(40, 10 + i * 9, 127 - 42, 8, map(ADCvalues[i], 600, 3500, 0, 85));
+      }
       display.drawVerticalLine(40 + map(RSSIthresholds[i], 600, 3500, 0, 85),  10 + i * 9, 8); // line to show the RSSIthresholds
     }
   } else if (displayScreenNumber % numberOfOledScreens == 1) {


### PR DESCRIPTION
Added a logic block to display an RSSI bar for 50 whenever the RSSI value drops below 50. This resolves the OLED artifacting and jumping to a full progress bar whenever RSSI dips too low.