### PR TITLE
Add missing ifdef to WebServer code.

### DIFF
--- a/ESP32LapTimer/WebServer.ino
+++ b/ESP32LapTimer/WebServer.ino
@@ -348,7 +348,9 @@ void ProcessGeneralSettingsUpdate() {
   size_t sent = webServer.streamFile(file, "text/html"); // And send it to the client
   file.close();
   eepromSaveRquired = true;
+#ifdef OLED
   oledUpdate();
+#endif
 
 //  PowerDownAll();
 //  SelectivePowerUp();


### PR DESCRIPTION
Add missing ifdef block to disable OledUpdate() inside WebServer code.
Fix compilation errors when oled is disabled in configuration.