### PR TITLE
adds rx module calibration

### DIFF
--- a/ESP32LapTimer/ADC.h
+++ b/ESP32LapTimer/ADC.h
@@ -5,8 +5,6 @@
 
 #define ADCmemLen 150
 
-bool hasRSSIReadingRefreshed = false;
-
 uint32_t SampleArrayMillisOffset; //value that stores the offset of the global millis(); time so we can relate the array sample time to the the global time via this offset. // Not used for the moment.
 
 uint16_t ADC1readings[ADCmemLen];

--- a/ESP32LapTimer/ADC.h
+++ b/ESP32LapTimer/ADC.h
@@ -5,6 +5,8 @@
 
 #define ADCmemLen 150
 
+bool hasRSSIReadingRefreshed = false;
+
 uint32_t SampleArrayMillisOffset; //value that stores the offset of the global millis(); time so we can relate the array sample time to the the global time via this offset. // Not used for the moment.
 
 uint16_t ADC1readings[ADCmemLen];

--- a/ESP32LapTimer/ADC.ino
+++ b/ESP32LapTimer/ADC.ino
@@ -65,8 +65,6 @@ void IRAM_ATTR nbADCread( void * pvParameters ) {
 
   while (1) {
 
-    uint8_t numReadings = 16;
-    uint32_t rawRSSIReading;
     xSemaphoreTake( xBinarySemaphore, portMAX_DELAY );
     uint32_t now = micros();
     //Serial.print(now - LastADCcall);
@@ -75,55 +73,49 @@ void IRAM_ATTR nbADCread( void * pvParameters ) {
     LastADCcall = now;
 
     adcAttachPin(ADC1_GPIO);
-    rawRSSIReading = 0;
-    for (int i = 0; i < numReadings; i++) {
-      adcStart(ADC1_GPIO);
-      rawRSSIReading += adcEnd(ADC1_GPIO);
+    adcStart(ADC1_GPIO);
+    while (adcBusy(ADC1_GPIO)) {
+      NOP();
     }
-    ADCReadingsRAW[0] = 2 * (rawRSSIReading / numReadings); //don't know why 2x is needed here!
+    ADCReadingsRAW[0] = 2 * adcEnd(ADC1_GPIO); //don't know why 2x is needed here!
 
     adcAttachPin(ADC2_GPIO);
-    rawRSSIReading = 0;
-    for (int i = 0; i < numReadings; i++) {
-      adcStart(ADC2_GPIO);
-      rawRSSIReading += adcEnd(ADC2_GPIO);
+    adcStart(ADC2_GPIO);
+    while (adcBusy(ADC2_GPIO)) {
+      NOP();
     }
-    ADCReadingsRAW[1] = 2 * (rawRSSIReading / numReadings); //don't know why 2x is needed here!
+    ADCReadingsRAW[1] = 2 * adcEnd(ADC2_GPIO); //don't know why 2x is needed here!
 
     adcAttachPin(ADC3_GPIO);
-    rawRSSIReading = 0;
-    for (int i = 0; i < numReadings; i++) {
-      adcStart(ADC3_GPIO);
-      rawRSSIReading += adcEnd(ADC3_GPIO);
+    adcStart(ADC3_GPIO);
+    while (adcBusy(ADC3_GPIO)) {
+      NOP();
     }
-    ADCReadingsRAW[2] = 2 * (rawRSSIReading / numReadings); //don't know why 2x is needed here!
+    ADCReadingsRAW[2] = 2 * adcEnd(ADC3_GPIO); //don't know why 2x is needed here!
 
 
     adcAttachPin(ADC4_GPIO);
-    rawRSSIReading = 0;
-    for (int i = 0; i < numReadings; i++) {
-      adcStart(ADC4_GPIO);
-      rawRSSIReading += adcEnd(ADC4_GPIO);
+    adcStart(ADC4_GPIO);
+    while (adcBusy(ADC4_GPIO)) {
+      NOP();
     }
-    ADCReadingsRAW[3] = 2 * (rawRSSIReading / numReadings); //don't know why 2x is needed here!
+    ADCReadingsRAW[3] = 2 * adcEnd(ADC4_GPIO); //don't know why 2x is needed here!
 
 
     adcAttachPin(ADC5_GPIO);
-    rawRSSIReading = 0;
-    for (int i = 0; i < numReadings; i++) {
-      adcStart(ADC5_GPIO);
-      rawRSSIReading += adcEnd(ADC5_GPIO);
+    adcStart(ADC5_GPIO);
+    while (adcBusy(ADC5_GPIO)) {
+      NOP();
     }
-    ADCReadingsRAW[4] = 2 * (rawRSSIReading / numReadings); //don't know why 2x is needed here!
+    ADCReadingsRAW[4] = 2 * adcEnd(ADC5_GPIO); //don't know why 2x is needed here!
 
 
     adcAttachPin(ADC6_GPIO);
-    rawRSSIReading = 0;
-    for (int i = 0; i < numReadings; i++) {
-      adcStart(ADC6_GPIO);
-      rawRSSIReading += adcEnd(ADC6_GPIO);
+    adcStart(ADC6_GPIO);
+    while (adcBusy(ADC6_GPIO)) {
+      NOP();
     }
-    ADCReadingsRAW[5] = 2 * (rawRSSIReading / numReadings); //don't know why 2x is needed here!
+    ADCReadingsRAW[5] = 2 * adcEnd(ADC6_GPIO); //don't know why 2x is needed here!
 
     // Applying calibration
     if (!isCurrentlyCalibrating) {
@@ -176,8 +168,6 @@ void IRAM_ATTR nbADCread( void * pvParameters ) {
 
     //ADCcaptime = micros() - ADCstartMicros;
     // Serial.println(ADCcaptime);
-
-    hasRSSIReadingRefreshed = true;
   }
 }
 

--- a/ESP32LapTimer/ADC.ino
+++ b/ESP32LapTimer/ADC.ino
@@ -120,7 +120,7 @@ void IRAM_ATTR nbADCread( void * pvParameters ) {
     // Applying calibration
     if (!isCurrentlyCalibrating) {
       for (uint8_t i = 0; i < NumRecievers; i++) {
-        uint16_t rawRSSI = ADCReadingsRAW[i];
+        uint16_t rawRSSI = constrain(ADCReadingsRAW[i], EepromSettings.RxCalibrationMin[i], EepromSettings.RxCalibrationMax[i]);
         ADCReadingsRAW[i] = map(rawRSSI, EepromSettings.RxCalibrationMin[i], EepromSettings.RxCalibrationMax[i], 800, 2700); // 800 and 2700 are about average min max raw values
       }
     }

--- a/ESP32LapTimer/Buttons.ino
+++ b/ESP32LapTimer/Buttons.ino
@@ -35,7 +35,12 @@ void buttonUpdate() {
   if(buttonTwoTouched &&  button2Timer.hasTicked()) {
     Serial.println("buttonTwoTouched");
     beep();
+    
     // Do button2 stuff in here
+    if (displayScreenNumber % numberOfOledScreens == 2) {
+      rssiCalibration();
+    }
+  
     buttonTwoTouched = false;
     button2Timer.reset();
   } else {

--- a/ESP32LapTimer/Calibration.h
+++ b/ESP32LapTimer/Calibration.h
@@ -1,0 +1,56 @@
+#include "ADC.h"
+#include "HardwareConfig.h"
+#include "RX5808.h"
+#include "settings_eeprom.h"
+
+int calibrationFreqIndex = 0;
+bool isCurrentlyCalibrating = false;
+
+void rssiCalibration() {
+
+  for (uint8_t i = 0; i < NumRecievers; i++) {
+    EepromSettings.RxCalibrationMin[i] = 5000;
+    EepromSettings.RxCalibrationMax[i] = 0;
+  }
+  
+  isCurrentlyCalibrating = true;
+  calibrationFreqIndex = 0;
+  setModuleFrequencyAll(channelFreqTable[calibrationFreqIndex]);
+  hasRSSIReadingRefreshed = false;
+  
+}
+
+void rssiCalibrationUpdate() {
+
+  if (isCurrentlyCalibrating && hasRSSIReadingRefreshed) {
+    
+    for (uint8_t i = 0; i < NumRecievers; i++) {
+      if (ADCReadingsRAW[i] < EepromSettings.RxCalibrationMin[i])
+        EepromSettings.RxCalibrationMin[i] = ADCReadingsRAW[i];
+        
+      if (ADCReadingsRAW[i] > EepromSettings.RxCalibrationMax[i])
+        EepromSettings.RxCalibrationMax[i] = ADCReadingsRAW[i];
+    }
+  
+    calibrationFreqIndex++;
+    
+    if (calibrationFreqIndex < 8*8) { // 8*8 = 8 bands * 8 channels = total number of freq in channelFreqTable.
+      
+      setModuleFrequencyAll(channelFreqTable[calibrationFreqIndex]);
+      hasRSSIReadingRefreshed = false;
+      
+    } else {
+      
+      for (int i = 0; i < NumRecievers; i++) {
+        setModuleChannelBand(i);
+      }
+      
+      isCurrentlyCalibrating = false;
+      eepromSaveRquired = true;
+      displayScreenNumber = 0;
+      
+    }  
+                 
+  }
+  
+}

--- a/ESP32LapTimer/ESP32LapTimer.ino
+++ b/ESP32LapTimer/ESP32LapTimer.ino
@@ -10,6 +10,7 @@
 #include "OLED.h"
 #include "WebServer.h"
 #include "Beeper.h"
+#include "Calibration.h"
 
 //#define BluetoothEnabled //uncomment this to use bluetooth (experimental, ble + wifi appears to cause issues)
 
@@ -81,17 +82,17 @@ void setup() {
 
   //SelectivePowerUp();
 
-  // inits modules with defaults
-  for (int i = 0; i < NumRecievers; i++) {
-    setModuleChannelBand(i);
-    delay(10);
+  // inits modules with defaults.  Loops 10 times  because some Rx modules dont initiate correctly.
+  for (int i = 0; i < NumRecievers*10; i++) {
+    setModuleChannelBand(i % NumRecievers);
   }
 
   beep();
-
 }
 
 void loop() {
+  rssiCalibrationUpdate();
+
   //  if (shouldReboot) {  //checks if reboot is needed
   //    Serial.println("Rebooting...");
   //    delay(100);

--- a/ESP32LapTimer/HardwareConfig.h
+++ b/ESP32LapTimer/HardwareConfig.h
@@ -8,12 +8,12 @@ void InitHardwarePins();
 
 // DO NOT CHANGE BELOW UNLESS USING CUSTOM HARDWARE
 
-#define EEPROM_VERSION_NUMBER 5 // Increment when eeprom struct modified
+#define EEPROM_VERSION_NUMBER 6 // Increment when eeprom struct modified
 
 #define MaxNumRecievers 6
 byte NumRecievers;
 
-#define MIN_TUNE_TIME 30
+#define MIN_TUNE_TIME 30000 // value in micro seconds
 
 #define OLED //uncomment this to enable OLED support
 

--- a/ESP32LapTimer/OLED.h
+++ b/ESP32LapTimer/OLED.h
@@ -2,3 +2,4 @@ void oledSetup();
 void oledUpdate();
 void OLED_CheckIfUpdateReq();
 uint16_t displayScreenNumber = 0;
+uint8_t  numberOfOledScreens = 3; // Increment if a new screen is added to cycle through.

--- a/ESP32LapTimer/OLED.ino
+++ b/ESP32LapTimer/OLED.ino
@@ -6,9 +6,6 @@
 #include "Timer.h"
 #include "Screensaver.h"
 
-//displayScreenNumber = 0;
-uint8_t  numberOfOledScreens = 2; // Increment if a new screen is added to cycle through.
-
 uint8_t oledRefreshTime = 50;
 Timer oledTimer = Timer(oledRefreshTime);
 
@@ -94,6 +91,18 @@ void oledUpdate(void)
       adcLoopCounter = 0;
 
       display.drawString(0, 9, String(mAReadingFloat) + " mA");
+    }
+  } else if (displayScreenNumber % numberOfOledScreens == 2) {
+    if (ADCVBATmode != 0) {
+      display.setTextAlignment(TEXT_ALIGN_LEFT);
+      display.drawString(0, 0, "Frequency - " + String(channelFreqTable[calibrationFreqIndex]) + "Hz");
+      display.drawString(0,  9, "Min = " + String(EepromSettings.RxCalibrationMin[0]) + ", Max = " + String(EepromSettings.RxCalibrationMax[0]));
+      display.drawString(0, 18, "Min = " + String(EepromSettings.RxCalibrationMin[1]) + ", Max = " + String(EepromSettings.RxCalibrationMax[1]));
+      display.drawString(0, 27, "Min = " + String(EepromSettings.RxCalibrationMin[2]) + ", Max = " + String(EepromSettings.RxCalibrationMax[2]));
+      display.drawString(0, 36, "Min = " + String(EepromSettings.RxCalibrationMin[3]) + ", Max = " + String(EepromSettings.RxCalibrationMax[3]));
+      display.drawString(0, 45, "Min = " + String(EepromSettings.RxCalibrationMin[4]) + ", Max = " + String(EepromSettings.RxCalibrationMax[4]));
+      display.drawString(0, 54, "Min = " + String(EepromSettings.RxCalibrationMin[5]) + ", Max = " + String(EepromSettings.RxCalibrationMax[5]));
+
     }
   }
 

--- a/ESP32LapTimer/RX5808.h
+++ b/ESP32LapTimer/RX5808.h
@@ -48,5 +48,6 @@ uint16_t setModuleChannel(uint8_t channel, uint8_t band);
 void InitSPI();
 void SetDefaultRegs();
 uint16_t setModuleChannelBand(uint8_t NodeAddr);
+uint16_t setModuleFrequencyAll(uint16_t frequency);
 
 #endif

--- a/ESP32LapTimer/RX5808.ino
+++ b/ESP32LapTimer/RX5808.ino
@@ -384,6 +384,13 @@ uint16_t setModuleFrequency(uint16_t frequency, uint8_t NodeAddr) {
   return frequency;
 }
 
+uint16_t setModuleFrequencyAll(uint16_t frequency) {
+
+  rxWriteAll(SPI_ADDRESS_SYNTH_B, getSynthRegisterBFreq(frequency));
+
+  return frequency;
+}
+
 String getBandLabel(int band) {
 
   switch (band) {

--- a/ESP32LapTimer/settings_eeprom.h
+++ b/ESP32LapTimer/settings_eeprom.h
@@ -32,6 +32,8 @@ struct EepromSettingsStruct {
   ADCVBATmode_ ADCVBATmode;
   float VBATcalibration;
   byte NumRecievers;
+  uint16_t RxCalibrationMin[MaxNumRecievers];
+  uint16_t RxCalibrationMax[MaxNumRecievers];
 
 
   void setup();
@@ -47,11 +49,13 @@ const struct {
   uint8_t RXBand[MaxNumRecievers] = {0, 0, 0, 0, 0, 0};
   uint8_t RXChannel[MaxNumRecievers] = {0, 1, 2, 3, 4, 5};
   uint16_t RXfrequencies[MaxNumRecievers] = {5658, 5695, 5732, 5769, 5806, 5843};
-      int RSSIthresholds[MaxNumRecievers] = {2048, 2048, 2048, 2048, 2048, 2048};
+  int RSSIthresholds[MaxNumRecievers] = {2048, 2048, 2048, 2048, 2048, 2048};
   RXADCfilter_ RXADCfilter = LPF_20Hz;
-  ADCVBATmode_ ADCVBATmode = ADC_CH5;
+  ADCVBATmode_ ADCVBATmode = INA219;
   float VBATcalibration = 1.000;
-  byte NumRecievers = 4;
+  byte NumRecievers = 6;
+  uint16_t RxCalibrationMin[MaxNumRecievers] = {800, 800, 800, 800, 800, 800};
+  uint16_t RxCalibrationMax[MaxNumRecievers] = {2700, 2700, 2700, 2700, 2700, 2700};
 
 } EepromDefaults;
 


### PR DESCRIPTION
Calibration feature is required for multiplexing Rx modules https://github.com/AlessandroAU/Chorus32-ESP32LapTimer/issues/49 https://github.com/AlessandroAU/Chorus32-ESP32LapTimer/issues/50

Calibration is not required if you are not multiplexing.

To perform a calibration navigate to the 3rd OLED screen (press the left touchpad twice) which displays the current min max RSSI values for each Rx module.  Place a quad/VTx on top of or close to the Chorus32 with the power set to 25mW.  Now press the right touchpad.

A sweep of the frequency table will be performed and record the min and max RSSI for each Rx module detected.  These values are used to map the rawRSSI measurements to a standard min 800 max 2700 range.

ADC readings changed to the average of 16 measurements to further reduce noise.

After testing with multiplexing the min max readings may need to be increased and a value stored for each frequency.