### PR TITLE
Added Airplane Mode Settings screen

### DIFF
--- a/ESP32LapTimer/Airplane.ino
+++ b/ESP32LapTimer/Airplane.ino
@@ -1,0 +1,27 @@
+#include "WebServer.h"
+
+bool airplaneMode = false;
+
+// Toggle Airplane mode on and off based on current state
+void toggleAirplaneMode() {
+  if (!airplaneMode) {
+    airplaneModeOn();
+  } else {
+    airplaneModeOff();
+  }
+}
+
+void airplaneModeOn() {
+  // Enable Airplane Mode (WiFi Off)
+  Serial.println("Airplane Mode On");
+  WiFi.mode(WIFI_OFF);
+  airplaneMode = true;
+}
+
+void airplaneModeOff() {
+  // Disable Airplane Mode (WiFi On)
+  Serial.println("Airplane Mode OFF");
+  InitWifiAP();
+  InitWebServer();
+  airplaneMode = false;
+}

--- a/ESP32LapTimer/Buttons.ino
+++ b/ESP32LapTimer/Buttons.ino
@@ -40,6 +40,11 @@ void buttonUpdate() {
     if (displayScreenNumber % numberOfOledScreens == 2) {
       rssiCalibration();
     }
+    
+    if (displayScreenNumber % numberOfOledScreens == 3) {
+      // Toggle Airplane Mode
+      toggleAirplaneMode();
+    }
   
     buttonTwoTouched = false;
     button2Timer.reset();

--- a/ESP32LapTimer/OLED.h
+++ b/ESP32LapTimer/OLED.h
@@ -2,4 +2,4 @@ void oledSetup();
 void oledUpdate();
 void OLED_CheckIfUpdateReq();
 uint16_t displayScreenNumber = 0;
-uint8_t  numberOfOledScreens = 3; // Increment if a new screen is added to cycle through.
+uint8_t  numberOfOledScreens = 4; // Increment if a new screen is added to cycle through.

--- a/ESP32LapTimer/OLED.ino
+++ b/ESP32LapTimer/OLED.ino
@@ -7,6 +7,7 @@
 #include "Screensaver.h"
 
 uint8_t oledRefreshTime = 50;
+
 Timer oledTimer = Timer(oledRefreshTime);
 
 SSD1306  display(0x3c, 21, 22);  // 21 and 22 are default pins
@@ -103,6 +104,19 @@ void oledUpdate(void)
       display.drawString(0, 45, "Min = " + String(EepromSettings.RxCalibrationMin[4]) + ", Max = " + String(EepromSettings.RxCalibrationMax[4]));
       display.drawString(0, 54, "Min = " + String(EepromSettings.RxCalibrationMin[5]) + ", Max = " + String(EepromSettings.RxCalibrationMax[5]));
 
+    }
+  } else if (displayScreenNumber % numberOfOledScreens == 3) {
+    
+    display.setTextAlignment(TEXT_ALIGN_LEFT);
+    display.drawString(0, 0, "Airplane Mode Settings:");
+    display.drawString(0, 15, "Press Btn2 to toggle, and");
+    display.drawString(0, 26, "use less energy if wired.");
+    if (!airplaneMode) {
+      display.drawString(0, 42, "Airplane Mode: OFF");
+      display.drawString(0, 51, "WiFi: ON  | Draw: " + String(mAReadingFloat/1000, 2) + "A");
+    } else {
+      display.drawString(0, 42, "Airplane Mode: ON");
+      display.drawString(0, 51, "WiFi: OFF  | Draw: " + String(mAReadingFloat/1000, 2) + "A");
     }
   }
 


### PR DESCRIPTION
Added a 4th screen with Airplane Mode Settings. This can be used to disable the internal WiFi radio in the ESP32 if you're using an external module (bluetooth or, for some reason, WiFI), or if you're hard-wiring to the timer with a USB cable. 