### PR TITLE
Added RX Frequency Change from OLED

### DIFF
--- a/ESP32LapTimer/Buttons.ino
+++ b/ESP32LapTimer/Buttons.ino
@@ -4,6 +4,8 @@
 #define buttonTouchThreshold 40
 #define buttonDeBounce 200
 
+uint8_t numberOfOledScreens = numberOfBaseScreens;
+
 bool buttonOneTouched = false;
 bool buttonTwoTouched = false;
 
@@ -24,6 +26,7 @@ void buttonUpdate() {
     beep();
     
     // Do button1 stuff in here
+    numberOfOledScreens = numberOfBaseScreens + (NumRecievers); // Re-calculating the number of screens while cycling through them
     displayScreenNumber++;
     
     buttonOneTouched = false;

--- a/ESP32LapTimer/Buttons.ino
+++ b/ESP32LapTimer/Buttons.ino
@@ -48,6 +48,11 @@ void buttonUpdate() {
       // Toggle Airplane Mode
       toggleAirplaneMode();
     }
+
+    if (displayScreenNumber % numberOfOledScreens >= 4 && displayScreenNumber % numberOfOledScreens <= 9) {
+      // Increment RX Frequency Here.
+      incrementRxFrequency();
+    }
   
     buttonTwoTouched = false;
     button2Timer.reset();

--- a/ESP32LapTimer/OLED.h
+++ b/ESP32LapTimer/OLED.h
@@ -2,4 +2,5 @@ void oledSetup();
 void oledUpdate();
 void OLED_CheckIfUpdateReq();
 uint16_t displayScreenNumber = 0;
-uint8_t  numberOfOledScreens = 4; // Increment if a new screen is added to cycle through.
+uint8_t  numberOfBaseScreens = 4; // Increment if a new screen is added to cycle through.
+// The actual number of screens will be calculated on Button 1 press in buttons.ino.

--- a/ESP32LapTimer/OLED.ino
+++ b/ESP32LapTimer/OLED.ino
@@ -103,10 +103,8 @@ void oledUpdate(void)
       display.drawString(0, 36, "Min = " + String(EepromSettings.RxCalibrationMin[3]) + ", Max = " + String(EepromSettings.RxCalibrationMax[3]));
       display.drawString(0, 45, "Min = " + String(EepromSettings.RxCalibrationMin[4]) + ", Max = " + String(EepromSettings.RxCalibrationMax[4]));
       display.drawString(0, 54, "Min = " + String(EepromSettings.RxCalibrationMin[5]) + ", Max = " + String(EepromSettings.RxCalibrationMax[5]));
-
     }
   } else if (displayScreenNumber % numberOfOledScreens == 3) {
-    
     display.setTextAlignment(TEXT_ALIGN_LEFT);
     display.drawString(0, 0, "Airplane Mode Settings:");
     display.drawString(0, 15, "Press Btn2 to toggle, and");
@@ -118,9 +116,49 @@ void oledUpdate(void)
       display.drawString(0, 42, "Airplane Mode: ON");
       display.drawString(0, 51, "WiFi: OFF  | Draw: " + String(mAReadingFloat/1000, 2) + "A");
     }
+  } else if (displayScreenNumber % numberOfOledScreens == 4) {
+    // Receiver 1 screen
+    displayRxPage();
+  } else if (displayScreenNumber % numberOfOledScreens == 5) {
+    // Receiver 2 screen
+    displayRxPage();
+  } else if (displayScreenNumber % numberOfOledScreens == 6) {
+    // Receiver 3 screen
+    displayRxPage();
+  } else if (displayScreenNumber % numberOfOledScreens == 7) {
+    // Receiver 4 screen
+    displayRxPage();
+  } else if (displayScreenNumber % numberOfOledScreens == 8) {
+    // Receiver 5 screen
+    displayRxPage();
+  } else if (displayScreenNumber % numberOfOledScreens == 9) {
+    // Receiver 6 screen
+    displayRxPage();
   }
 
   display.display();
+}
+
+void displayRxPage() {
+  // Gather Data
+  int currentRXNumber = (displayScreenNumber % numberOfOledScreens) - 4;
+  uint8_t frequencyIndex = RXChannel[currentRXNumber] + (8 * RXBand[currentRXNumber]);
+  uint16_t frequency = channelFreqTable[frequencyIndex];
+
+  // Display things
+  display.setTextAlignment(TEXT_ALIGN_LEFT);
+  display.setFont(ArialMT_Plain_16);
+  display.drawString(0, 0, "Settings for RX" + String(currentRXNumber + 1));
+  display.drawString(0, 20, getBandLabel(RXBand[currentRXNumber]) + String(RXChannel[currentRXNumber] + 1) + " - " + frequency);
+  if (ADCvalues[currentRXNumber] < 600) {
+    display.drawProgressBar(45, 40, 122 - 42, 8, map(600, 600, 3500, 0, 85));
+  } else {
+    display.drawProgressBar(45, 40, 122 - 42, 8, map(ADCvalues[currentRXNumber], 600, 3500, 0, 85));
+  }
+  display.setFont(Dialog_plain_9);
+  display.drawString(0,40, "RSSI: " + String(ADCvalues[currentRXNumber] / 12));
+  display.drawVerticalLine(45 + map(RSSIthresholds[currentRXNumber], 600, 3500, 0, 85),  40, 8); // line to show the RSSIthresholds
+  display.drawString(0,53, "Btn 2 to cycle frequencies.");
 }
 
 #endif

--- a/ESP32LapTimer/OLED.ino
+++ b/ESP32LapTimer/OLED.ino
@@ -126,7 +126,7 @@ void oledUpdate(void)
 
 void displayRxPage() {
   // Gather Data
-  int currentRXNumber = (displayScreenNumber % numberOfOledScreens) - 4;
+  uint8_t currentRXNumber = (displayScreenNumber % numberOfOledScreens) - 4;
   uint8_t frequencyIndex = RXChannel[currentRXNumber] + (8 * RXBand[currentRXNumber]);
   uint16_t frequency = channelFreqTable[frequencyIndex];
 
@@ -148,7 +148,20 @@ void displayRxPage() {
 
 void incrementRxFrequency() {
   Serial.println("Increment");
-  setModuleChannelBand(7,2,0); 
+  uint8_t currentRXNumber = (displayScreenNumber % numberOfOledScreens) - 4;
+  uint8_t currentRXChannel = RXChannel[currentRXNumber];
+  uint8_t currentRXBand = RXBand[currentRXNumber];
+  currentRXChannel++;
+  if (currentRXChannel >= 8) {
+    currentRXBand++;
+    currentRXChannel = 0;
+  }
+  if (currentRXBand >= 7 && currentRXChannel >= 2) {
+    currentRXBand = 0;
+    currentRXChannel = 0;
+  }
+  
+  setModuleChannelBand(currentRXChannel,currentRXBand,currentRXNumber); 
 }
 
 #endif

--- a/ESP32LapTimer/OLED.ino
+++ b/ESP32LapTimer/OLED.ino
@@ -116,23 +116,8 @@ void oledUpdate(void)
       display.drawString(0, 42, "Airplane Mode: ON");
       display.drawString(0, 51, "WiFi: OFF  | Draw: " + String(mAReadingFloat/1000, 2) + "A");
     }
-  } else if (displayScreenNumber % numberOfOledScreens == 4) {
-    // Receiver 1 screen
-    displayRxPage();
-  } else if (displayScreenNumber % numberOfOledScreens == 5) {
-    // Receiver 2 screen
-    displayRxPage();
-  } else if (displayScreenNumber % numberOfOledScreens == 6) {
-    // Receiver 3 screen
-    displayRxPage();
-  } else if (displayScreenNumber % numberOfOledScreens == 7) {
-    // Receiver 4 screen
-    displayRxPage();
-  } else if (displayScreenNumber % numberOfOledScreens == 8) {
-    // Receiver 5 screen
-    displayRxPage();
-  } else if (displayScreenNumber % numberOfOledScreens == 9) {
-    // Receiver 6 screen
+  } else if (displayScreenNumber % numberOfOledScreens >= 4 && displayScreenNumber % numberOfOledScreens <= 9) {
+    // RX Settings Pages here.
     displayRxPage();
   }
 
@@ -151,14 +136,19 @@ void displayRxPage() {
   display.drawString(0, 0, "Settings for RX" + String(currentRXNumber + 1));
   display.drawString(0, 20, getBandLabel(RXBand[currentRXNumber]) + String(RXChannel[currentRXNumber] + 1) + " - " + frequency);
   if (ADCvalues[currentRXNumber] < 600) {
-    display.drawProgressBar(45, 40, 122 - 42, 8, map(600, 600, 3500, 0, 85));
+    display.drawProgressBar(48, 40, 120 - 42, 8, map(600, 600, 3500, 0, 85));
   } else {
-    display.drawProgressBar(45, 40, 122 - 42, 8, map(ADCvalues[currentRXNumber], 600, 3500, 0, 85));
+    display.drawProgressBar(48, 40, 120 - 42, 8, map(ADCvalues[currentRXNumber], 600, 3500, 0, 85));
   }
   display.setFont(Dialog_plain_9);
   display.drawString(0,40, "RSSI: " + String(ADCvalues[currentRXNumber] / 12));
   display.drawVerticalLine(45 + map(RSSIthresholds[currentRXNumber], 600, 3500, 0, 85),  40, 8); // line to show the RSSIthresholds
   display.drawString(0,53, "Btn 2 to cycle frequencies.");
+}
+
+void incrementRxFrequency() {
+  Serial.println("Increment");
+  setModuleChannelBand(7,2,0); 
 }
 
 #endif

--- a/ESP32LapTimer/RX5808.ino
+++ b/ESP32LapTimer/RX5808.ino
@@ -317,12 +317,13 @@ uint16_t setModuleChannelBand(uint8_t channel, uint8_t band, uint8_t NodeAddr) {
   Serial.print(channel);
   Serial.print(",");
   Serial.println(band);
-
+  
   uint8_t index = channel + (8 * band);
   Serial.println(index);
   uint16_t frequency = channelFreqTable[index];
   //return setModuleFrequency(frequency);
-
+  RXBand[NodeAddr] = band;
+  RXChannel[NodeAddr] = channel;
   switch (NodeAddr) {
     case 0:
       rxWrite(SPI_ADDRESS_SYNTH_B, getSynthRegisterBFreq(frequency), CS1);


### PR DESCRIPTION
Added the ability to change the RX frequencies from the OLED. There are new screens dynamically adjusted based on the number of RX modules activated. From there, you can select the screen for a given RX and adjust the frequency of that RX by pressing Button 2. 