### PR TITLE
Skip ADC calibration for voltage monitor pin

### DIFF
--- a/ESP32LapTimer/ADC.ino
+++ b/ESP32LapTimer/ADC.ino
@@ -120,6 +120,7 @@ void IRAM_ATTR nbADCread( void * pvParameters ) {
     // Applying calibration
     if (!isCurrentlyCalibrating) {
       for (uint8_t i = 0; i < NumRecievers; i++) {
+        if((ADCVBATmode == ADC_CH5 && i == 4) || (ADCVBATmode == ADC_CH6 && i == 5)) continue; // skip if voltage is on this channel
         uint16_t rawRSSI = constrain(ADCReadingsRAW[i], EepromSettings.RxCalibrationMin[i], EepromSettings.RxCalibrationMax[i]);
         ADCReadingsRAW[i] = map(rawRSSI, EepromSettings.RxCalibrationMin[i], EepromSettings.RxCalibrationMax[i], 800, 2700); // 800 and 2700 are about average min max raw values
       }


### PR DESCRIPTION
When using ADC5 or ADC6 as battery monitor it doesn't make sense to apply the calibration values, which only limits the range and screws up the results