### PR TITLE
Characterize adc to fight the non-linearity

### DIFF
--- a/ESP32LapTimer/Comms.ino
+++ b/ESP32LapTimer/Comms.ino
@@ -559,16 +559,8 @@ void SendLipoVoltage() {
   uint8_t buf[4];
   float VbatFloat;
 
-  switch (ADCVBATmode) {
-    case ADC_CH5:
-      VbatFloat = ((float(VbatReadingSmooth * VBATcalibration) / 11) * (1024.0 / 4.53)) / 1024;
-      break;
-    case ADC_CH6:
-      VbatFloat = ((float(VbatReadingSmooth * VBATcalibration) / 11) * (1024.0 / 4.53)) / 1024;
-      break;
-    case INA219:
-      VbatFloat = (VbatReadingFloat / 11.0) * (1024.0 / 5.0); // App expects raw pin reading through a potential divider.
-      break;
+  if(ADCVBATmode != OFF) {
+    VbatFloat = (VbatReadingFloat / 11.0) * (1024.0 / 5.0); // App expects raw pin reading through a potential divider.
   }
 
   intToHex(buf, int(VbatFloat));

--- a/ESP32LapTimer/OLED.ino
+++ b/ESP32LapTimer/OLED.ino
@@ -28,12 +28,6 @@ void OLED_CheckIfUpdateReq() {
     oledUpdate();
     oledTimer.reset();
   }
-  //Serial.println(VbatReadingRaw);
-
-  if (ADCVBATmode != INA219) {
-    VbatReadingFloat = fmap(VbatReadingSmooth * VBATcalibration, 0, 4096, 0, 4.4);
-  }
-  //Serial.println(VbatReading);
 }
 
 void oledUpdate(void)


### PR DESCRIPTION
The ESP32 has a really awful non-linearity up to the point where it is impossible to monitor different battery sizes. With this approach this is drastically decreased and usable.
Additionally we don't need to differentiate between the ina219 and adc reading outside of ADC.ino

This probably needs the adc attenuation fix.

With this I get 4.9V at 5V input and 22.2V at 22V input (using a 10/1 divider), before it was a few Volts off target