### PR TITLE
Allow remapping of SPI pins

### DIFF
--- a/ESP32LapTimer/HardwareConfig.h
+++ b/ESP32LapTimer/HardwareConfig.h
@@ -26,3 +26,14 @@ extern byte NumRecievers;
 
 
 #include "targets/target.h" // Needs to be at the bottom
+
+// Define unconfigured pins
+#ifndef SCK
+#define SCK -1
+#endif
+#ifndef MOSI
+#define MOSI -1
+#endif
+#ifndef MISO
+#define MISO -1
+#endif

--- a/ESP32LapTimer/RX5808.cpp
+++ b/ESP32LapTimer/RX5808.cpp
@@ -24,12 +24,7 @@ volatile uint8_t RXBand[MaxNumRecievers];
 volatile uint8_t RXChannel[MaxNumRecievers];
 
 void InitSPI() {
-#ifdef USE_HSPI
-  SPI.begin(SCK, MISO, MOSI, -1);
-#endif
-#ifdef USE_VSPI
-  SPI.begin();
-#endif
+  SPI.begin(SCK, MISO, MOSI);
   delay(200);
 }
 

--- a/ESP32LapTimer/targets/config_default.h
+++ b/ESP32LapTimer/targets/config_default.h
@@ -5,8 +5,6 @@
 #define BUTTON1 T7 // 27
 #define BUTTON2 T4 // 13
 
-#define USE_VSPI
-
 #define CS1 16
 #define CS2 5
 #define CS3 4

--- a/ESP32LapTimer/targets/config_old.h
+++ b/ESP32LapTimer/targets/config_old.h
@@ -5,8 +5,6 @@
 #define BUTTON1 T7 // 27
 #define BUTTON2 T4 // 13
 
-#define USE_HSPI
-
 #define SCK 14
 #define MOSI 12
 

--- a/ESP32LapTimer/targets/config_ttgo_lora_v1.h
+++ b/ESP32LapTimer/targets/config_ttgo_lora_v1.h
@@ -6,8 +6,6 @@
   
 #define BUTTON1 13
 #define BUTTON2 12
-  
-#define USE_VSPI
 
 #define CS1 16
 #define CS2 5


### PR DESCRIPTION
VSPI and HSPI don't really differ, as they are just names for spi2 and spi3.
The object "SPI" is actually always VSPI, so the setting didn't do anything.