### PR TITLE
Run the ADC  task with 6khz but only sample one channel at a time

### DIFF
--- a/ESP32LapTimer/ADC.h
+++ b/ESP32LapTimer/ADC.h
@@ -6,9 +6,9 @@
 #include "Filter.h"
 
 void ConfigureADC();
-void InitADCtimer();
 void IRAM_ATTR CheckRSSIthresholdExceeded();
 void ReadVBAT_INA219();
+void IRAM_ATTR nbADCread( void * pvParameters );
 
 uint16_t getRSSI(uint8_t index);
 void setRSSIThreshold(uint8_t node, uint16_t threshold);

--- a/ESP32LapTimer/ESP32LapTimer.ino
+++ b/ESP32LapTimer/ESP32LapTimer.ino
@@ -1,6 +1,9 @@
 #include <WiFi.h>
 #include <ESPmDNS.h>
 #include <WiFiUdp.h>
+
+#include <esp_task_wdt.h>
+
 #include "Comms.h"
 #include "ADC.h"
 #include "HardwareConfig.h"
@@ -16,12 +19,34 @@
 #include "UDP.h"
 #include "Buttons.h"
 #include "WebServer.h"
+#include "Watchdog.h"
 
 //#define BluetoothEnabled //uncomment this to use bluetooth (experimental, ble + wifi appears to cause issues)
 
 //
 #define MAX_SRV_CLIENTS 5
 WiFiClient serverClients[MAX_SRV_CLIENTS];
+
+SemaphoreHandle_t adc_semaphore;
+
+void IRAM_ATTR adc_read() {
+  static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+  /* un-block the interrupt processing task now */
+  xSemaphoreGiveFromISR( adc_semaphore, &xHigherPriorityTaskWoken );
+  if ( xHigherPriorityTaskWoken) {
+    portYIELD_FROM_ISR(); // this wakes up sample_timer_task immediately
+  }
+}
+
+void IRAM_ATTR adc_task(void* args) {
+  watchdog_add_task();
+  while(42) {
+    xSemaphoreTake( adc_semaphore, portMAX_DELAY );
+    nbADCread(NULL);
+    watchdog_feed();
+  }
+}
+
 
 void setup() {
 
@@ -63,7 +88,12 @@ void setup() {
     setRSSIThreshold(i, EepromSettings.RSSIthresholds[i]);
   }
 
-  InitADCtimer();
+  adc_semaphore = xSemaphoreCreateBinary();
+  hw_timer_t* adc_task_timer = timerBegin(0, 8, true);
+  timerAttachInterrupt(adc_task_timer, &adc_read, true);
+  timerAlarmWrite(adc_task_timer, 1667, true); // 6khz -> 1khz per adc channel
+  timerAlarmEnable(adc_task_timer);
+  xTaskCreatePinnedToCore(adc_task, "ADCreader", 4096, NULL, 1, NULL, 0);
 
   //SelectivePowerUp();
 

--- a/ESP32LapTimer/Watchdog.c
+++ b/ESP32LapTimer/Watchdog.c
@@ -1,0 +1,16 @@
+#include "Watchdog.h"
+
+#include <stdint.h>
+#include <soc/timer_group_struct.h>
+#include <soc/timer_group_reg.h>
+#include <esp_task_wdt.h>
+
+void watchdog_add_task() {
+	esp_task_wdt_add(NULL);
+}
+
+void watchdog_feed() {
+	TIMERG0.wdt_wprotect = TIMG_WDT_WKEY_VALUE;
+	TIMERG0.wdt_feed = 1;
+	TIMERG0.wdt_wprotect = 0;
+}

--- a/ESP32LapTimer/Watchdog.h
+++ b/ESP32LapTimer/Watchdog.h
@@ -1,0 +1,17 @@
+#ifndef __WATCHDOG_H__
+#define __WATCHDOG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+void watchdog_add_task();
+void watchdog_feed();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // __WATCHDOG_H__


### PR DESCRIPTION
Not quite sure if you'll like this change. 
First of all I think it would be preferable to have all task definitions in a central place.
By running the task with a rate of 6KHz we eliminate all for loops and thus simplifying the code.
Since the filter parameters are fixed for now the loop uses all receivers.

In the future this will enable us to increase the sampling rate when there are less than 6 modules and either get more samples or just let them run faster.
Also makes implementing multiplexing much easier (if you are interested in this)