### PR TITLE
Set the time adjustment to calibrated

### DIFF
--- a/ESP32LapTimer/Comms.cpp
+++ b/ESP32LapTimer/Comms.cpp
@@ -131,7 +131,7 @@ static uint32_t raceStartTime = 0;
 // Usage of signed int time adjustment constant from outside:
 // * set to zero means time adjustment procedure was not performed for this node
 // * set to INFINITE_TIME_ADJUSTMENT, means time adjustment was performed, but no need to adjust
-static int32_t timeAdjustment = 0;
+static int32_t timeAdjustment = INFINITE_TIME_ADJUSTMENT;
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Calibration is not needed since we only have one microcontroller.

No need to wait 10 seconds when using multiple modules