### PR TITLE
Move lap logic to Laptime

### DIFF
--- a/ESP32LapTimer/Comms.cpp
+++ b/ESP32LapTimer/Comms.cpp
@@ -179,10 +179,8 @@ void setRaceMode(uint8_t mode) {
     //playEndRaceTones();
   } else { // start race in specified mode
     //holeShot = true;
-    RaceStartTime = millis();
     raceMode = mode;
-    raceStartTime = millis();
-    lastMilliseconds = raceStartTime;
+    startRaceLap();
     newLapIndex = 0;
     for(uint8_t i = 0; i < NumRecievers; ++i) {
       if(thresholdSetupMode[i]) {
@@ -401,36 +399,20 @@ void setupThreshold(uint8_t phase, uint8_t node) {
 }
 
 void IRAM_ATTR sendLap(uint8_t Lap, uint8_t NodeAddr) {
-
-  //  Serial.print("SendLap: ");
-  //  Serial.println(String(Lap) + " " + String(NodeAddr));
-
   uint32_t RequestedLap = 0;
 
-  if (raceMode == 0) {
-    Serial.println("RaceMode == 0 and sendlaps was called");
+  if (Lap == 0) {
+    Serial.println("Lap == 0 and sendlap was called");
     return;
   }
 
-
-  //  if (Lap == 1) {  ///ugh need to fix this logic at some point but it works for now
-  //    RequestedLap = LapTimes[NodeAddr][Lap] - RaceStartTime;
-  //  } else {
   if (raceMode == 1) {
-
-    if (Lap == 1) {
-      RequestedLap = getLaptime(NodeAddr, Lap) - RaceStartTime; // realtive mode
-    } else {
-      RequestedLap = getLaptime(NodeAddr, Lap) - getLaptime(NodeAddr, Lap - 1); // realtive mode
-    }
-
+    RequestedLap = getLaptimeRel(NodeAddr, Lap); // realtive mode
   } else if (raceMode == 2) {
-    RequestedLap = getLaptime(NodeAddr, Lap) - RaceStartTime;  //absolute mode
-
+    RequestedLap = getLaptimeRelToStart(NodeAddr, Lap);  //absolute mode
   } else {
     Serial.println("Error: Invalid RaceMode Set");
   }
-  //}
 
   uint8_t buf1[2];
   uint8_t buf2[8];
@@ -444,9 +426,7 @@ void IRAM_ATTR sendLap(uint8_t Lap, uint8_t NodeAddr) {
 
   longToHex(buf2, RequestedLap);
   addToSendQueue(buf2, 8);
-
   addToSendQueue('\n');
-
 }
 
 void SendNumberOfnodes(byte NodeAddr) {

--- a/ESP32LapTimer/Laptime.cpp
+++ b/ESP32LapTimer/Laptime.cpp
@@ -5,13 +5,14 @@
 #include "HardwareConfig.h"
 
 static volatile uint32_t LapTimes[MaxNumRecievers][100];
-static volatile int LapTimePtr[MaxNumRecievers] = {0, 0, 0, 0, 0, 0}; //Keep track of what lap we are up too
+static volatile int lap_counter[MaxNumRecievers] = {0, 0, 0, 0, 0, 0}; //Keep track of what lap we are up too
 
 static uint32_t MinLapTime = 5000;  //this is in millis
+static uint32_t start_time = 0;
 
 void resetLaptimes() {
   for (int i = 0; i < NumRecievers; ++i) {
-    LapTimePtr[i] = 0;
+    lap_counter[i] = 0;
   }
 }
 
@@ -20,13 +21,30 @@ uint32_t getLaptime(uint8_t receiver, uint8_t lap) {
 }
 
 uint32_t getLaptime(uint8_t receiver) {
-  return getLaptime(receiver, LapTimePtr[receiver]);
+  return getLaptime(receiver, lap_counter[receiver]);
+}
+
+uint32_t getLaptimeRel(uint8_t receiver, uint8_t lap) {
+  if(lap == 1) {
+    return getLaptime(receiver, lap) - start_time;
+  } else if(lap == 0) {
+    return 0;
+  }
+  return getLaptime(receiver, lap) - getLaptime(receiver, lap - 1);
+}
+
+uint32_t getLaptimeRelToStart(uint8_t receiver, uint8_t lap) {
+  return getLaptime(receiver, lap) - start_time;
+}
+
+uint32_t getLaptimeRel(uint8_t receiver) {
+  return getLaptimeRel(receiver, lap_counter[receiver]);
 }
 
 uint8_t addLap(uint8_t receiver, uint32_t time) {
-  LapTimePtr[receiver] = LapTimePtr[receiver] + 1;
-  LapTimes[receiver][LapTimePtr[receiver]] = time;
-  return LapTimePtr[receiver];
+  lap_counter[receiver] = lap_counter[receiver] + 1;
+  LapTimes[receiver][lap_counter[receiver]] = time;
+  return lap_counter[receiver];
 }
 
 uint32_t getMinLapTime() {
@@ -38,5 +56,10 @@ void setMinLapTime(uint32_t time) {
 }
 
 uint8_t getCurrentLap(uint8_t receiver) {
-  return LapTimePtr[receiver];
+  return lap_counter[receiver];
+}
+
+void startRaceLap() {
+  resetLaptimes();
+  start_time = millis();
 }

--- a/ESP32LapTimer/Laptime.h
+++ b/ESP32LapTimer/Laptime.h
@@ -9,11 +9,17 @@ uint32_t getMinLapTime();
 void setMinLapTime(uint32_t time);
 uint32_t getLaptime(uint8_t receiver);
 uint32_t getLaptime(uint8_t receiver, uint8_t lap);
+uint32_t getLaptimeRel(uint8_t receiver, uint8_t lap);
+uint32_t getLaptimeRelToStart(uint8_t receiver, uint8_t lap);
+uint32_t getLaptimeRel(uint8_t receiver);
+void startRaceLap();
+
 
 /**
  * Adds a lap to the pool and returns the current lap id
  */
 uint8_t addLap(uint8_t receiver, uint32_t time);
+/// Laps begin at 1. lap 0 is always 0
 uint8_t getCurrentLap(uint8_t receiver);
 
 #endif // __LAPTIME_H__


### PR DESCRIPTION
Fix undefined behavior when requesting lap 0

Also I think sendlap should be allowed when not in race mode.
A possible scenario would be dropped packets, a disconnect or others connecting to get their times after a race