### PR TITLE
Enable serial output by default

### DIFF
--- a/ESP32LapTimer/HardwareConfig.h
+++ b/ESP32LapTimer/HardwareConfig.h
@@ -27,6 +27,7 @@ extern byte NumRecievers;
 #define MAX_UDP_CLIENTS 5
 
 //#define USE_BLUETOOTH // Disabled by default. If you enable it you might need to change the partition scheme to "Huge APP"
+#define USE_SERIAL_OUTPUT
 
 #include "targets/target.h" // Needs to be at the bottom
 


### PR DESCRIPTION
Since most users just want their timer to work, I think this should be enabled by default.