### PR TITLE
Move voltage reading of the critical path

### DIFF
--- a/ESP32LapTimer/ADC.cpp
+++ b/ESP32LapTimer/ADC.cpp
@@ -16,8 +16,6 @@
 #include "Laptime.h"
 #include "Utils.h"
 
-static Timer ina219Timer = Timer(1000);
-
 static Adafruit_INA219 ina219; // A0+A1=GND
 
 static uint32_t LastADCcall;
@@ -89,11 +87,8 @@ void IRAM_ATTR nbADCread( void * pvParameters ) {
 
   // Applying calibration
   if (LIKELY(!isCalibrating())) {
-    // skip if voltage is on this channel
-    if(!(getADCVBATmode() == ADC_CH5 && current_adc == 4) || (getADCVBATmode() == ADC_CH6 && current_adc == 5)) {
-      uint16_t rawRSSI = constrain(ADCReadingsRAW[current_adc], EepromSettings.RxCalibrationMin[current_adc], EepromSettings.RxCalibrationMax[current_adc]);
-      ADCReadingsRAW[current_adc] = map(rawRSSI, EepromSettings.RxCalibrationMin[current_adc], EepromSettings.RxCalibrationMax[current_adc], 800, 2700); // 800 and 2700 are about average min max raw values
-    }
+    uint16_t rawRSSI = constrain(ADCReadingsRAW[current_adc], EepromSettings.RxCalibrationMin[current_adc], EepromSettings.RxCalibrationMax[current_adc]);
+    ADCReadingsRAW[current_adc] = map(rawRSSI, EepromSettings.RxCalibrationMin[current_adc], EepromSettings.RxCalibrationMax[current_adc], 800, 2700); // 800 and 2700 are about average min max raw values
   }
 
   switch (getRXADCfilter()) {
@@ -111,19 +106,6 @@ void IRAM_ATTR nbADCread( void * pvParameters ) {
       break;
   }
 
-  switch (getADCVBATmode()) {
-    case ADC_CH5:
-      VbatReadingSmooth = esp_adc_cal_raw_to_voltage(ADCvalues[4], &adc_chars);
-      setVbatFloat(VbatReadingSmooth / 1000.0 * VBATcalibration);
-      break;
-    case ADC_CH6:
-      VbatReadingSmooth = esp_adc_cal_raw_to_voltage(ADCvalues[5], &adc_chars);
-      setVbatFloat(VbatReadingSmooth / 1000.0 * VBATcalibration);
-      break;
-    default:
-      break;
-  }
-
   if (LIKELY(isInRaceMode() > 0)) {
     CheckRSSIthresholdExceeded(current_adc);
   }
@@ -132,11 +114,8 @@ void IRAM_ATTR nbADCread( void * pvParameters ) {
 
 
 void ReadVBAT_INA219() {
-  if (ina219Timer.hasTicked()) {
-    setVbatFloat(ina219.getBusVoltage_V() + (ina219.getShuntVoltage_mV() / 1000));
-    mAReadingFloat = ina219.getCurrent_mA();
-    ina219Timer.reset();
-  }
+  setVbatFloat(ina219.getBusVoltage_V() + (ina219.getShuntVoltage_mV() / 1000));
+  mAReadingFloat = ina219.getCurrent_mA();
 }
 
 void IRAM_ATTR CheckRSSIthresholdExceeded(uint8_t node) {
@@ -182,7 +161,25 @@ float getMaFloat() {
   return mAReadingFloat;
 }
 
-float getVbatFloat(){
+float getVbatFloat(bool force_read){
+  static uint32_t last_voltage_update = 0;
+  if((millis() - last_voltage_update) > VOLTAGE_UPDATE_INTERVAL_MS || force_read) {
+    switch (getADCVBATmode()) {
+      case ADC_CH5:
+        VbatReadingSmooth = esp_adc_cal_raw_to_voltage(adc1_get_raw(ADC5), &adc_chars);
+        setVbatFloat(VbatReadingSmooth / 1000.0 * VBATcalibration);
+        break;
+      case ADC_CH6:
+        VbatReadingSmooth = esp_adc_cal_raw_to_voltage(adc1_get_raw(ADC6), &adc_chars);
+        setVbatFloat(VbatReadingSmooth / 1000.0 * VBATcalibration);
+        break;
+      case INA219:
+        ReadVBAT_INA219();
+      default:
+        break;
+    }
+    last_voltage_update = millis();
+  }
   return VbatReadingFloat;
 }
 

--- a/ESP32LapTimer/ADC.h
+++ b/ESP32LapTimer/ADC.h
@@ -19,7 +19,7 @@ void setADCLoopCount(uint16_t count);
 void setVbatCal(float calibration);
 float getMaFloat();
 
-float getVbatFloat();
+float getVbatFloat(bool force_read = false);
 void setVbatFloat(float val);
 
 float getVBATcalibration();

--- a/ESP32LapTimer/ESP32LapTimer.ino
+++ b/ESP32LapTimer/ESP32LapTimer.ino
@@ -130,9 +130,6 @@ void loop() {
   updateWifi();
 
   EepromSettings.save();
-  if (getADCVBATmode() == INA219) {
-    ReadVBAT_INA219();
-  }
   beeperUpdate();
   if(UNLIKELY(!isInRaceMode())) {
     thresholdModeStep();

--- a/ESP32LapTimer/HardwareConfig.h
+++ b/ESP32LapTimer/HardwareConfig.h
@@ -20,6 +20,8 @@ void InitHardwarePins();
 #define MaxNumRecievers 6
 extern byte NumRecievers;
 
+#define VOLTAGE_UPDATE_INTERVAL_MS 1000
+
 #define MIN_TUNE_TIME 30000 // value in micro seconds
 
 #define OLED //uncomment this to enable OLED support


### PR DESCRIPTION
This moves the voltage reading to a separate path and only actually updates the value when VOLTAGE_UPDATE_INTERVAL_MS time is elapsed.
This way the ADC and INA219 options are equal in regards of update time.
Also significantly improves readability of the voltage on a display using the ADC.

As I don't have an INA219 I was only able to test it with ADC reading
