### PR TITLE
Send all laps when requesting all settings

### DIFF
--- a/ESP32LapTimer/Comms.cpp
+++ b/ESP32LapTimer/Comms.cpp
@@ -588,6 +588,7 @@ void SendAllSettings(uint8_t NodeAddr) {
   SendVRxFreq(NodeAddr);
   SendRSSImonitorInterval(NodeAddr);
   SendTimerCalibration(NodeAddr);
+  SendAllLaps(NodeAddr);
   sendAPIversion();
   sendThresholdMode(NodeAddr);
   SendXdone(NodeAddr);
@@ -612,7 +613,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
   }
 
 
-  if (controlData[2] == 'a') {
+  if (controlData[2] == CONTROL_GET_ALL_DATA) {
     for (int i = 0; i < getNumReceivers(); i++) {
       SendAllSettings(i);
       //delay(100);


### PR DESCRIPTION
This is especially helpful if you are out of range during flying and then connect again to get your times.

This is in line with the API documentation and works without a problem using the app. But as I don't have a copy of Windows, I am unable to test if there are any problems when using LiveTime.