### PR TITLE
Implement module multiplexing

### DIFF
--- a/ESP32LapTimer/src/ADC.cpp
+++ b/ESP32LapTimer/src/ADC.cpp
@@ -19,6 +19,7 @@
 #include <driver/adc.h>
 #include <driver/timer.h>
 #include <esp_adc_cal.h>
+#include <Arduino.h>
 
 #include <Wire.h>
 #include <Adafruit_INA219.h>
@@ -32,6 +33,10 @@
 #include "Calibration.h"
 #include "Laptime.h"
 #include "Utils.h"
+#include "RX5808.h"
+#include "Queue.h"
+
+#include "Filter.h"
 
 static Adafruit_INA219 ina219; // A0+A1=GND
 
@@ -39,24 +44,57 @@ static uint32_t LastADCcall;
 
 static esp_adc_cal_characteristics_t adc_chars;
 
-static int RSSIthresholds[MAX_NUM_RECEIVERS];
-static uint16_t ADCReadingsRAW[MAX_NUM_RECEIVERS];
 static unsigned int VbatReadingSmooth;
-static int ADCvalues[MAX_NUM_RECEIVERS];
 static uint16_t adcLoopCounter = 0;
-
-static FilterBeLp2_10HZ Filter_10HZ[6] = {FilterBeLp2_10HZ(), FilterBeLp2_10HZ(), FilterBeLp2_10HZ(), FilterBeLp2_10HZ(), FilterBeLp2_10HZ(), FilterBeLp2_10HZ()};
-static FilterBeLp2_20HZ Filter_20HZ[6] = {FilterBeLp2_20HZ(), FilterBeLp2_20HZ(), FilterBeLp2_20HZ(), FilterBeLp2_20HZ(), FilterBeLp2_20HZ(), FilterBeLp2_20HZ()};
-static FilterBeLp2_50HZ Filter_50HZ[6] = {FilterBeLp2_50HZ(), FilterBeLp2_50HZ(), FilterBeLp2_50HZ(), FilterBeLp2_50HZ(), FilterBeLp2_50HZ(), FilterBeLp2_50HZ()};
-static FilterBeLp2_100HZ Filter_100HZ[6] = {FilterBeLp2_100HZ(), FilterBeLp2_100HZ(), FilterBeLp2_100HZ(), FilterBeLp2_100HZ(), FilterBeLp2_100HZ(), FilterBeLp2_100HZ()};
 
 static float VBATcalibration;
 static float mAReadingFloat;
 static float VbatReadingFloat;
 
+// count of current active pilots
+static uint8_t current_pilot_num = 0;
+
 static adc1_channel_t ADC_PINS[MAX_NUM_RECEIVERS] = {ADC1, ADC2, ADC3, ADC4, ADC5, ADC6};
 
-static uint16_t multisample_adc1(adc1_channel_t channel, uint8_t samples) {
+// number of cascading lowpass filter per pilot
+#define PILOT_FILTER_NUM 1
+
+enum pilot_state {
+  PILOT_UNUSED,
+  PILOT_ACTIVE,
+};
+
+typedef struct receiver_data_s receiver_data_t;
+
+typedef struct pilot_data_s {
+  uint16_t RSSIthreshold;
+  uint16_t ADCReadingRAW;
+  uint16_t ADCvalue;
+  lowpass_filter_t filter[PILOT_FILTER_NUM];
+  /// Pilot state 0: unsused, 1: active
+  uint8_t state;
+  receiver_data_t* current_rx;
+  uint8_t number;
+  uint32_t unused_time; // used to force a certain stay time. if we allow an instant switch, modules would be constantly switching with e.g. 6 modules and 7 pilots
+  bool disable_multiplexing; // don't switch this pilot. scenario: 3 modules installed with 4 pilots. 2 pilots really care about their time and the other 2 just want to see their approximate time. so fix the first two pilots and the remaining module multiplexes the other 2
+} pilot_data_t;
+
+typedef struct receiver_data_s {
+  uint32_t last_hop;
+  pilot_data_t* current_pilot;
+} receiver_data_t;
+
+static pilot_data_t pilots[MAX_NUM_PILOTS];
+static receiver_data_t receivers[MAX_NUM_RECEIVERS];
+
+// multiplexing queue
+static queue_t pilot_queue;
+static pilot_data_t* pilot_queue_data[MAX_NUM_PILOTS];
+
+SemaphoreHandle_t pilot_queue_lock;
+SemaphoreHandle_t pilots_lock;
+
+uint16_t multisample_adc1(adc1_channel_t channel, uint8_t samples) {
   uint32_t val = 0;
   for(uint8_t i = 0; i < samples; ++i) {
     val += adc1_get_raw(channel);
@@ -64,7 +102,63 @@ static uint16_t multisample_adc1(adc1_channel_t channel, uint8_t samples) {
   return val/samples;
 }
 
+/**
+ * Find next free pilot and set them to busy. Marks the old pilot as active. Sets the current pilot for the given module
+ * \returns if a different pilot was found.
+ */
+static IRAM_ATTR bool setNextPilot(uint8_t adc) {
+  // skip this receiver if the assigned pilot is fixed
+  if(receivers[adc].current_pilot && receivers[adc].current_pilot->disable_multiplexing) {
+    return false;
+  }
+  if(!xSemaphoreTake(pilot_queue_lock, 1)) {
+    // failed to obtain mutex, so do nothing
+    return false;
+  }
+  pilot_data_t* new_pilot = (pilot_data_t*)queue_peek(&pilot_queue);
+  bool ret_val = false;
+  if(new_pilot) {
+    if(new_pilot->state == PILOT_ACTIVE) {
+      if((micros() - new_pilot->unused_time) > MULTIPLEX_STAY_TIME_US + MIN_TUNE_TIME_US){
+        new_pilot = (pilot_data_t*)queue_dequeue(&pilot_queue);
+        // set old pilot to active again
+        if(receivers[adc].current_pilot && receivers[adc].current_pilot->state != PILOT_UNUSED) {
+          receivers[adc].current_pilot->state = PILOT_ACTIVE;
+          receivers[adc].current_pilot->current_rx = NULL;
+          // readd to multiplex queue
+          queue_enqueue(&pilot_queue, receivers[adc].current_pilot);
+          receivers[adc].current_pilot->unused_time = micros();
+        }
+        new_pilot->current_rx = &receivers[adc];
+        receivers[adc].current_pilot = new_pilot;
+        ret_val = true;
+      }
+    } else { // pilot went inactive
+      new_pilot = (pilot_data_t*)queue_dequeue(&pilot_queue); // Dequeue inactive pilot
+      if(new_pilot->current_rx) {
+        new_pilot->current_rx->current_pilot = NULL;
+        new_pilot->current_rx = NULL;
+      }
+    }
+  }
+  xSemaphoreGive(pilot_queue_lock);
+  // Do nothing it the pilot is not active
+  return ret_val;
+}
+
 void ConfigureADC() {
+
+  pilot_queue_lock = xSemaphoreCreateMutex();
+  pilots_lock = xSemaphoreCreateMutex();
+
+  memset(pilots, 0, MAX_NUM_PILOTS * sizeof(pilot_data_t));
+  for(int i = 0; i < MAX_NUM_PILOTS; ++i) {
+    pilots[i].number = i;
+  }
+  memset(receivers, 0, MAX_NUM_RECEIVERS * sizeof(receiver_data_t));
+  pilot_queue.curr_size = 0;
+  pilot_queue.max_size = MAX_NUM_PILOTS;
+  pilot_queue.data = (void**)pilot_queue_data;
 
   adc1_config_width(ADC_WIDTH_BIT_12);
 
@@ -77,49 +171,81 @@ void ConfigureADC() {
 
   ina219.begin();
   ReadVBAT_INA219();
+  float cutoff = 0;
+  switch (getRXADCfilter()) {
+  case LPF_10Hz:
+    cutoff = 10;
+    break;
+  case LPF_20Hz:
+    cutoff = 20;
+    break;
+  case LPF_50Hz:
+    cutoff = 50;
+    break;
+  case LPF_100Hz:
+    cutoff = 100;
+    break;
+  }
 
+  setPilotFilters(cutoff);
+  // By default enable getNumReceivers() pilots
+  for(uint8_t i = 0; i < getNumReceivers() && i < MAX_NUM_PILOTS; ++i)  {
+    setPilotActive(i, true);
+  }
+}
+
+adc1_channel_t IRAM_ATTR getADCChannel(uint8_t adc_num) {
+  adc1_channel_t channel = ADC_PINS[MIN(adc_num, MAX_NUM_RECEIVERS - 1)];
+  return channel;
 }
 
 void IRAM_ATTR nbADCread( void * pvParameters ) {
   static uint8_t current_adc = 0;
-  if(current_adc == 0) ++adcLoopCounter; // only count adc number 0 to get the frequency per module
-
   uint32_t now = micros();
-  LastADCcall = now;
-  adc1_channel_t channel = ADC_PINS[MIN(current_adc, MAX_NUM_RECEIVERS - 1)];
+  if(xSemaphoreTake(pilots_lock, 1)) { // lock changes to pilots from other cores
+    if(now - receivers[current_adc].last_hop > MULTIPLEX_STAY_TIME_US + MIN_TUNE_TIME_US && isRxReady(current_adc)) {
+      if(setNextPilot(current_adc)) {
+        // TODO: add class between this and rx5808
+        // TODO: add better multiplexing. Maybe based on the last laptime?
+        setModuleChannelBand(getRXChannelPilot(receivers[current_adc].current_pilot->number), getRXBandPilot(receivers[current_adc].current_pilot->number), current_adc);
+        receivers[current_adc].last_hop = now;
+      }
+    }
+    // go to next adc if vrx is not ready or has no assigned pilot
+    if(isRxReady(current_adc) && receivers[current_adc].current_pilot) {
+      adc1_channel_t channel = getADCChannel(current_adc);
+      pilot_data_t* current_pilot = receivers[current_adc].current_pilot;
+      if(current_pilot) {
+        if(LIKELY(isInRaceMode())) {
+          current_pilot->ADCReadingRAW = adc1_get_raw(channel);
+        } else {
+          // multisample when not in race mode (for threshold calibration etc)
+          current_pilot->ADCReadingRAW = multisample_adc1(channel, 10);
+        }
 
-  if(LIKELY(isInRaceMode())) {
-    ADCReadingsRAW[current_adc] = adc1_get_raw(channel);
-  } else {
-    // multisample when not in race mode (for threshold calibration etc)
-    ADCReadingsRAW[current_adc] = multisample_adc1(channel, 10);
-  }
+        // Applying calibration
+        uint16_t rawRSSI = constrain(current_pilot->ADCReadingRAW, EepromSettings.RxCalibrationMin[current_adc], EepromSettings.RxCalibrationMax[current_adc]);
+        current_pilot->ADCReadingRAW = map(rawRSSI, EepromSettings.RxCalibrationMin[current_adc], EepromSettings.RxCalibrationMax[current_adc], RSSI_ADC_READING_MIN, RSSI_ADC_READING_MAX);
 
-  // Applying calibration
-  if (LIKELY(!isCalibrating())) {
-    uint16_t rawRSSI = constrain(ADCReadingsRAW[current_adc], EepromSettings.RxCalibrationMin[current_adc], EepromSettings.RxCalibrationMax[current_adc]);
-    ADCReadingsRAW[current_adc] = map(rawRSSI, EepromSettings.RxCalibrationMin[current_adc], EepromSettings.RxCalibrationMax[current_adc], RSSI_ADC_READING_MIN, RSSI_ADC_READING_MAX);
-  }
+        current_pilot->ADCvalue = current_pilot->ADCReadingRAW;
+        for(uint8_t j = 0; j < PILOT_FILTER_NUM; ++j) {
+          current_pilot->ADCvalue = filter_add_value(&(current_pilot->filter[j]), current_pilot->ADCvalue);
+        }
 
-  switch (getRXADCfilter()) {
-    case LPF_10Hz:
-      ADCvalues[current_adc] = Filter_10HZ[current_adc].step(ADCReadingsRAW[current_adc]);
-      break;
-    case LPF_20Hz:
-      ADCvalues[current_adc] = Filter_20HZ[current_adc].step(ADCReadingsRAW[current_adc]);
-      break;
-    case LPF_50Hz:
-      ADCvalues[current_adc] = Filter_50HZ[current_adc].step(ADCReadingsRAW[current_adc]);
-      break;
-    case LPF_100Hz:
-      ADCvalues[current_adc] = Filter_100HZ[current_adc].step(ADCReadingsRAW[current_adc]);
-      break;
-  }
+        if (LIKELY(isInRaceMode() > 0)) {
+          CheckRSSIthresholdExceeded(receivers[current_adc].current_pilot->number);
+        }
 
-  if (LIKELY(isInRaceMode() > 0)) {
-    CheckRSSIthresholdExceeded(current_adc);
+        if(current_pilot->number == 0){
+           ++adcLoopCounter;
+         }
+      }
+    } // end if isRxReady
+    xSemaphoreGive(pilots_lock);
   }
-  current_adc = (current_adc + 1) % MAX_NUM_RECEIVERS;
+  // use minimum here to ensure the first n receivers are used since the other ones might be offline in case we have more rx than pilots
+  // use max to avoid division by 0
+  current_adc = (current_adc + 1) % MAX(1, MIN(getNumReceivers(), current_pilot_num));
 }
 
 
@@ -128,30 +254,30 @@ void ReadVBAT_INA219() {
   mAReadingFloat = ina219.getCurrent_mA();
 }
 
-void IRAM_ATTR CheckRSSIthresholdExceeded(uint8_t node) {
+void IRAM_ATTR CheckRSSIthresholdExceeded(uint8_t pilot) {
   uint32_t CurrTime = millis();
-  if ( ADCvalues[node] > RSSIthresholds[node]) {
-    if (CurrTime > (getMinLapTime() + getLaptime(node))) {
-      addLap(node, CurrTime);
+  if ( pilots[pilot].ADCvalue > pilots[pilot].RSSIthreshold) {
+    if (CurrTime > (getMinLapTime() + getLaptime(pilot))) {
+      addLap(pilot, CurrTime);
     }
   }
 }
 
-uint16_t getRSSI(uint8_t index) {
-  if(index < MAX_NUM_RECEIVERS) {
-    return ADCvalues[index];
+uint16_t getRSSI(uint8_t pilot) {
+  if(pilot < MAX_NUM_PILOTS) {
+    return pilots[pilot].ADCvalue;
   }
   return 0;
 }
 
 void setRSSIThreshold(uint8_t node, uint16_t threshold) {
-  if(node < MAX_NUM_RECEIVERS) {
-    RSSIthresholds[node] = threshold;
+  if(node < MAX_NUM_PILOTS) {
+    pilots[node].RSSIthreshold = threshold;
   }
 }
 
 uint16_t getRSSIThreshold(uint8_t node){
-  return RSSIthresholds[node];
+  return pilots[node].RSSIthreshold;
 }
 
 uint16_t getADCLoopCount() {
@@ -203,3 +329,123 @@ void setVBATcalibration(float val) {
 float getVBATcalibration() {
   return VBATcalibration;
 }
+
+uint8_t getActivePilots() {
+  return current_pilot_num;
+}
+
+bool isPilotActive(uint8_t pilot) {
+  return pilots[pilot].state != PILOT_UNUSED;
+}
+
+void setPilotActive(uint8_t pilot, bool active) {
+  // First we power up all modules. If we have less pilots than modules they get activated at a later stage. As this function will never be called during a race this should be okay
+  // There might be a way better solution, but this will have to suffice for now
+  // XXX: We have to reset the module since it won't come online with a simple power up
+
+  // Power down all modules
+  for(uint8_t i = 0; i < MAX_NUM_RECEIVERS; ++i) {
+    RXPowerDown(i);
+  }
+  while(!xSemaphoreTake(pilot_queue_lock, portMAX_DELAY)); // Wait until this is free. this is a non critical section
+  while(!xSemaphoreTake(pilots_lock, portMAX_DELAY));
+  pilot_queue.curr_size = 0; // delete complete queue
+  if(active) {
+    if(pilots[pilot].state == PILOT_UNUSED) {
+      // If the pilot was unused until now, we set them to active and add them to the queue
+      pilots[pilot].state = PILOT_ACTIVE;
+    }
+  } else {
+    if(pilots[pilot].state != PILOT_UNUSED) {
+      pilots[pilot].state = PILOT_UNUSED;
+      // Set adc values to 0 for display etc
+      pilots[pilot].ADCvalue = 0;
+      pilots[pilot].ADCReadingRAW = 0;
+      // Since the pilot state is now unused, it won't get added back to the queue
+    }
+  }
+  current_pilot_num = 0;
+  // rebuild queue and delete all asignments. again this ist non-critical and the safest way to avoid bugs
+  for(int i = 0; i < getNumReceivers(); ++i) {
+    receivers[i].current_pilot = NULL;
+  }
+  for(int i = 0; i < MAX_NUM_PILOTS; ++i) {
+    // first reset all rx assignments
+    pilots[i].current_rx = NULL;
+    if(pilots[i].state == PILOT_ACTIVE) {
+      ++current_pilot_num;
+      queue_enqueue(&pilot_queue, &pilots[i]);
+    }
+  }
+
+  Serial.print("New pilot num: ");
+  Serial.println(current_pilot_num);
+
+  // only reset active modules. a user might have 6 modules installed but only uses 4. using the all function all modules would power up
+  for(int i = 0; i < MIN(current_pilot_num, getNumReceivers()); ++i) {
+    RXreset(i);
+    while(!isRxReady(i));
+  }
+
+  // adjust the filters for all active pilots
+  // Turns out just using the sample frequency and completely ignore the down time works the best. Still leaving this here in case this idea isn't so bad after all
+  /*for(uint8_t i = 0; i < MAX_NUM_PILOTS; ++i) {
+    // check both rx and pilots for 0 to avoid division by 0
+    if(pilots[i].state != PILOT_UNUSED && getNumReceivers() && current_pilot_num) {
+      uint32_t total_pilot_time_us = ((MULTIPLEX_STAY_TIME_US + MIN_TUNE_TIME_US) * current_pilot_num); // Total time for all pilots
+      float on_fraction = MULTIPLEX_STAY_TIME_US / (float)total_pilot_time_us * getNumReceivers(); // on percentage of the pilot
+      // special case for non multiplexing
+      if(current_pilot_num <= getNumReceivers()) {
+        on_fraction = 1.0/current_pilot_num;
+      }
+      for(uint8_t j = 0; j < PILOT_FILTER_NUM; ++j) {
+        filter_adjust_dt(&pilots[i].filter[j], 1.0/(6000.0 * on_fraction)); // set sampling rate
+        // when multiplexing we are using the average sampling rate per pilot as a timebase
+      }
+      Serial.printf("Set filtering cutoff to %f hz\n", (6000.0 * on_fraction));
+    }
+  }*/
+
+  xSemaphoreGive(pilot_queue_lock);
+  xSemaphoreGive(pilots_lock);
+}
+
+bool isPilotMultiplexOff(uint8_t pilot) {
+  return pilots[pilot].disable_multiplexing;
+}
+
+void setPilotMultiplexOff(uint8_t pilot, bool off) {
+  pilots[pilot].disable_multiplexing = off;
+}
+
+void setPilotFilters(uint16_t cutoff) {
+  for(uint8_t i = 0; i < MAX_NUM_PILOTS; ++i) {
+    for(uint8_t j = 0; j < PILOT_FILTER_NUM; ++j) {
+      filter_init(&pilots[i].filter[j], cutoff, 166 * getNumReceivers() * 1e-6);
+    }
+  }
+}
+
+void setPilotChannel(uint8_t pilot, uint8_t channel) {
+  setRXChannelPilot(pilot, channel);
+  EepromSettings.RXChannel[pilot] = channel;
+  setSaveRequired();
+  if(isPilotActive(pilot)) {
+    // Toggle pilot to force new channel
+    setPilotActive(pilot, false);
+    setPilotActive(pilot, true);
+  }
+}
+
+
+void setPilotBand(uint8_t pilot, uint8_t band) {
+  setRXBandPilot(pilot, band);
+  EepromSettings.RXBand[pilot] = band;
+  setSaveRequired();
+  if(isPilotActive(pilot)) {
+    // Toggle pilot to force new band
+    setPilotActive(pilot, false);
+    setPilotActive(pilot, true);
+  }
+}
+

--- a/ESP32LapTimer/src/ADC.cpp
+++ b/ESP32LapTimer/src/ADC.cpp
@@ -1,5 +1,5 @@
 /*
- * This file is part of Chorus32-ESP32LapTimer 
+ * This file is part of Chorus32-ESP32LapTimer
  * (see https://github.com/AlessandroAU/Chorus32-ESP32LapTimer).
  *
  * This program is free software: you can redistribute it and/or modify
@@ -72,7 +72,7 @@ typedef struct pilot_data_s {
   /// Pilot state 0: unsused, 1: active
   uint8_t state;
   receiver_data_t* current_rx;
-  uint8_t number;
+  uint8_t number; // the number of the pilot. is the same as the position in the array. this is used for fast access to that number from the queue
   uint32_t unused_time; // used to force a certain stay time. if we allow an instant switch, modules would be constantly switching with e.g. 6 modules and 7 pilots
   bool disable_multiplexing; // don't switch this pilot. scenario: 3 modules installed with 4 pilots. 2 pilots really care about their time and the other 2 just want to see their approximate time. so fix the first two pilots and the remaining module multiplexes the other 2
 } pilot_data_t;
@@ -117,6 +117,7 @@ static IRAM_ATTR bool setNextPilot(uint8_t adc) {
   bool ret_val = false;
   if(new_pilot) {
     if(new_pilot->state == PILOT_ACTIVE) {
+      // If the pilot is active and had didn't have an rx assigned in the specified time, we assign this pilot to the given adc
       if((micros() - new_pilot->unused_time) > MULTIPLEX_STAY_TIME_US + MIN_TUNE_TIME_US){
         new_pilot = (pilot_data_t*)queue_dequeue(&pilot_queue);
         // set old pilot to active again

--- a/ESP32LapTimer/src/ADC.h
+++ b/ESP32LapTimer/src/ADC.h
@@ -54,4 +54,8 @@ void setPilotFilters(uint16_t cutoff);
 
 void setPilotBand(uint8_t pilot, uint8_t band);
 void setPilotChannel(uint8_t pilot, uint8_t channel);
+void setPilotFrequency(uint8_t pilot, uint16_t frequency);
 
+uint8_t getPilotBand(uint8_t pilot);
+uint8_t getPilotChannel(uint8_t pilot);
+uint16_t getPilotFrequency(uint8_t pilot);

--- a/ESP32LapTimer/src/ADC.h
+++ b/ESP32LapTimer/src/ADC.h
@@ -19,6 +19,7 @@
 
 #include <esp_attr.h>
 #include <stdint.h>
+#include <driver/adc.h>
 
 #include "HardwareConfig.h"
 #include "Filter.h"
@@ -27,6 +28,8 @@ void ConfigureADC();
 void IRAM_ATTR CheckRSSIthresholdExceeded(uint8_t node);
 void ReadVBAT_INA219();
 void IRAM_ATTR nbADCread( void * pvParameters );
+adc1_channel_t IRAM_ATTR getADCChannel(uint8_t adc_num);
+uint16_t multisample_adc1(adc1_channel_t channel, uint8_t samples);
 
 uint16_t getRSSI(uint8_t index);
 void setRSSIThreshold(uint8_t node, uint16_t threshold);
@@ -42,3 +45,13 @@ void setVbatFloat(float val);
 
 float getVBATcalibration();
 void setVBATcalibration(float val);
+
+// TODO: these don't belong here!
+uint8_t getActivePilots();
+bool isPilotActive(uint8_t pilot);
+void setPilotActive(uint8_t pilot, bool active);
+void setPilotFilters(uint16_t cutoff);
+
+void setPilotBand(uint8_t pilot, uint8_t band);
+void setPilotChannel(uint8_t pilot, uint8_t channel);
+

--- a/ESP32LapTimer/src/Comms.cpp
+++ b/ESP32LapTimer/src/Comms.cpp
@@ -86,6 +86,7 @@
 #define CONTROL_NUM_RECIEVERS       'N'
 #define CONTROL_SOUND               'S'
 #define CONTROL_THRESHOLD           'T'
+#define CONTROL_PILOT_ACTIVE        'A'
 // get only:
 #define CONTROL_GET_API_VERSION     '#'
 #define CONTROL_WILDCARD_INDICATOR  '*'
@@ -108,6 +109,7 @@
 #define RESPONSE_MIN_LAP_TIME        'M'
 #define RESPONSE_SOUND               'S'
 #define RESPONSE_THRESHOLD           'T'
+#define RESPONSE_PILOT_ACTIVE        'A'
 
 #define RESPONSE_API_VERSION         '#'
 #define RESPONSE_RSSI                'r'
@@ -171,8 +173,7 @@ static uint8_t raceMode = 0; // 0: race mode is off; 1: lap times are counted re
 static uint8_t isConfigured = 0; //changes to 1 if any input changes the state of the device. it will mean that externally stored preferences should not be applied
 static uint8_t shouldWaitForFirstLap = 0; // 0 means start table is before the laptimer, so first lap is not a full-fledged lap (i.e. don't respect min-lap-time for the very first lap)
 
-static uint8_t thresholdSetupMode[MAX_NUM_RECEIVERS];
-static uint16_t RXfrequencies[MAX_NUM_RECEIVERS];
+static uint8_t thresholdSetupMode[MAX_NUM_PILOTS];
 
 static void sendThresholdMode(uint8_t node) {
   addToSendQueue('S');
@@ -183,26 +184,21 @@ static void sendThresholdMode(uint8_t node) {
 }
 
 void commsSetup() {
-  for (int i = 0; i < getNumReceivers(); i++) {
-    setRXBand(i, EepromSettings.RXBand[i]);
-    setRXChannel(i, EepromSettings.RXChannel[i]);
-    RXfrequencies[i] = EepromSettings.RXfrequencies[i];
+  for (int i = 0; i < MAX_NUM_PILOTS; i++) {
     thresholdSetupMode[i] = 0;
   }
 }
 
 void setRaceMode(uint8_t mode) {
   if (mode == 0) { // stop race
-
     resetLaptimes();
-
     raceMode = 0;
     //playEndRaceTones();
   } else { // start race in specified mode
     //holeShot = true;
     raceMode = mode;
     startRaceLap();
-    for(uint8_t i = 0; i < getNumReceivers(); ++i) {
+    for(uint8_t i = 0; i < MAX_NUM_PILOTS; ++i) {
       if(thresholdSetupMode[i]) {
         thresholdSetupMode[i] = 0;
         sendThresholdMode(i);
@@ -211,7 +207,6 @@ void setRaceMode(uint8_t mode) {
     //playStartRaceTones();
   }
 }
-
 
 void setMinLap(uint8_t mlt) {
   if (mlt >= MIN_MIN_LAP_TIME && mlt <= MAX_MIN_LAP_TIME) {
@@ -230,7 +225,7 @@ void SendMinLap(uint8_t NodeAddr) {
 }
 
 void SendIsModuleConfigured() {
-  for (int i = 0; i < getNumReceivers(); i ++) {
+  for (int i = 0; i < MAX_NUM_PILOTS; i ++) {
     addToSendQueue('S');
     addToSendQueue(TO_HEX(i));
     addToSendQueue(RESPONSE_IS_CONFIGURED);
@@ -274,7 +269,7 @@ void SendMillis() {
   uint8_t buf[8];
   longToHex(buf, CurrMillis);
 
-  for (int i = 0; i < getNumReceivers(); i ++) {
+  for (int i = 0; i < MAX_NUM_PILOTS; i ++) {
     addToSendQueue('S');
     addToSendQueue(TO_HEX(i));
     addToSendQueue(RESPONSE_TIME);
@@ -316,7 +311,7 @@ void SendCurrRSSIloop() {
     return;
   }
   if (millis() > rssiMonitorInterval + lastRSSIsent) {
-    for (int i = 0; i < getNumReceivers(); i ++) {
+    for (int i = 0; i < MAX_NUM_PILOTS; i ++) {
       SendCurrRSSI(i);
     }
   }
@@ -340,11 +335,11 @@ void setupThreshold(uint8_t phase, uint8_t node) {
 #define RISE_RSSI_THRESHOLD_PERCENT 25 // rssi value should pass this percentage above low value to continue finding the peak and further fall down of rssi
 #define FALL_RSSI_THRESHOLD_PERCENT 50 // rssi should fall below this percentage of diff between high and low to finalize setup of the threshold
 
-  static uint16_t rssiLow[MAX_NUM_RECEIVERS];
-  static uint16_t rssiHigh[MAX_NUM_RECEIVERS];
-  static uint16_t rssiHighEnoughForMonitoring[MAX_NUM_RECEIVERS];
-  static uint32_t accumulatedShiftedRssi[MAX_NUM_RECEIVERS]; // accumulates rssi slowly; contains multiplied rssi value for better accuracy
-  static uint32_t lastRssiAccumulationTime[MAX_NUM_RECEIVERS];
+  static uint16_t rssiLow[MAX_NUM_PILOTS];
+  static uint16_t rssiHigh[MAX_NUM_PILOTS];
+  static uint16_t rssiHighEnoughForMonitoring[MAX_NUM_PILOTS];
+  static uint32_t accumulatedShiftedRssi[MAX_NUM_PILOTS]; // accumulates rssi slowly; contains multiplied rssi value for better accuracy
+  static uint32_t lastRssiAccumulationTime[MAX_NUM_PILOTS];
 
   if (!thresholdSetupMode[node]) return;
 
@@ -364,7 +359,6 @@ void setupThreshold(uint8_t phase, uint8_t node) {
     // active phase step (searching for high value and fall down)
     if (thresholdSetupMode[node] == 1) {
       // in this phase of the setup we are tracking rssi growth until it reaches the predefined percentage from low
-
       // searching for peak; using slowRssi to avoid catching sudden random peaks
       if (rssi > rssiHigh[node]) {
         rssiHigh[node] = rssi;
@@ -388,7 +382,6 @@ void setupThreshold(uint8_t phase, uint8_t node) {
       }
     } else {
       // in this phase of the setup we are tracking highest rssi and expect it to fall back down so that we know that the process is complete
-
       // continue searching for peak; using slowRssi to avoid catching sudden random peaks
       if (rssi > rssiHigh[node]) {
         rssiHigh[node] = rssi;
@@ -451,20 +444,28 @@ void IRAM_ATTR sendLap(uint8_t Lap, uint8_t NodeAddr) {
 
 void SendNumberOfnodes() {
     addToSendQueue('N');
-    addToSendQueue(TO_HEX(getNumReceivers()));
+    addToSendQueue(TO_HEX(MAX_NUM_PILOTS));
     addToSendQueue('\n');
 }
 
 void IRAM_ATTR SendAllLaps(uint8_t NodeAddr) {
-  uint8_t Pointer = getCurrentLap(NodeAddr);
-  for (uint8_t i = 0; i < Pointer; i++) {
+  uint8_t lap_count = getCurrentLap(NodeAddr);
+  for (uint8_t i = 0; i < lap_count; i++) {
     sendLap(i + 1, NodeAddr);
     update_outputs(); // Flush outputs as the buffer could overflow with a large number of laps
   }
 }
 
-void SendRSSImonitorInterval(uint8_t NodeAddr) {
+void sendPilotActive(uint8_t pilot) {
+  uint8_t status = isPilotActive(pilot);
+  addToSendQueue('S');
+  addToSendQueue(TO_HEX(pilot));
+  addToSendQueue('A');
+  addToSendQueue(TO_HEX(status));
+  addToSendQueue('\n');
+}
 
+void SendRSSImonitorInterval(uint8_t NodeAddr) {
   addToSendQueue('S');
   addToSendQueue(TO_HEX(NodeAddr));
   uint8_t buf[4];
@@ -533,7 +534,7 @@ void SendVRxBand(uint8_t NodeAddr) {
   addToSendQueue('S');
   addToSendQueue(TO_HEX(NodeAddr));
   addToSendQueue(RESPONSE_BAND);
-  addToSendQueue(TO_HEX(getRXBand(NodeAddr)));
+  addToSendQueue(TO_HEX(getRXBandPilot(NodeAddr)));
   addToSendQueue('\n');
   //SendVRxFreq(NodeAddr);
 
@@ -544,7 +545,7 @@ void SendVRxChannel(uint8_t NodeAddr) {
   addToSendQueue('S');
   addToSendQueue(TO_HEX(NodeAddr));
   addToSendQueue(RESPONSE_CHANNEL);
-  addToSendQueue(TO_HEX(getRXChannel(NodeAddr)));
+  addToSendQueue(TO_HEX(getRXChannelPilot(NodeAddr)));
   addToSendQueue('\n');
   //SendVRxFreq(NodeAddr);
 
@@ -552,7 +553,7 @@ void SendVRxChannel(uint8_t NodeAddr) {
 
 void SendVRxFreq(uint8_t NodeAddr) {
   //Cmd Byte F
-  uint8_t index = getRXChannel(NodeAddr) + (8 * getRXBand(NodeAddr));
+  uint8_t index = getRXChannelPilot(NodeAddr) + (8 * getRXBandPilot(NodeAddr));
   uint16_t frequency = channelFreqTable[index];
 
   addToSendQueue('S');
@@ -567,7 +568,7 @@ void SendVRxFreq(uint8_t NodeAddr) {
 
 void sendAPIversion() {
 
-  for (int i = 0; i < getNumReceivers(); i++) {
+  for (int i = 0; i < MAX_NUM_PILOTS; i++) {
     addToSendQueue('S');
     addToSendQueue(TO_HEX(i));
     addToSendQueue(RESPONSE_API_VERSION);
@@ -629,6 +630,7 @@ void SendAllSettings(uint8_t NodeAddr) {
   SendAllLaps(NodeAddr);
   sendAPIversion();
   sendThresholdMode(NodeAddr);
+  sendPilotActive(NodeAddr);
   SendXdone(NodeAddr);
 
   update_outputs(); // Flush output after each node to prevent lost messages
@@ -653,7 +655,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
 
 
   if (controlData[2] == CONTROL_GET_ALL_DATA) {
-    for (int i = 0; i < getNumReceivers(); i++) {
+    for (int i = 0; i < MAX_NUM_PILOTS; i++) {
       SendAllSettings(i);
       //delay(100);
     }
@@ -671,10 +673,15 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
   if (length > 4) { // set value commands  changed to n+1 ie, 3+1 = 4.
     switch (ControlByte) {
 
+    case CONTROL_PILOT_ACTIVE:
+      valueToSet = TO_BYTE(controlData[3]);
+      setPilotActive(NodeAddrByte, valueToSet);
+      break;
+
       case CONTROL_RACE_MODE:
         valueToSet = TO_BYTE(controlData[3]);
         setRaceMode(valueToSet);
-        for (int i = 0; i < getNumReceivers(); i++) {
+        for (int i = 0; i < MAX_NUM_PILOTS; i++) {
           SendRaceMode(i);
         }
         isConfigured = 1;
@@ -688,37 +695,21 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         break;
 
       case CONTROL_BAND:
-
-        setRXBand(NodeAddrByte, TO_BYTE(controlData[3]));
-        setModuleChannelBand(NodeAddrByte);
+        setPilotBand(NodeAddrByte, TO_BYTE(controlData[3]));
         SendVRxBand(NodeAddrByte);
         SendVRxFreq(NodeAddrByte);
         isConfigured = 1;
-        EepromSettings.RXBand[NodeAddrByte] = getRXBand(NodeAddrByte);
-        setSaveRequired();
         break;
 
       case CONTROL_CHANNEL:
-
-        setRXChannel(NodeAddrByte, TO_BYTE(controlData[3]));
-        setModuleChannelBand(NodeAddrByte);
+        setPilotChannel(NodeAddrByte, TO_BYTE(controlData[3]));
         SendVRxChannel(NodeAddrByte);
         SendVRxFreq(NodeAddrByte);
         isConfigured = 1;
-        EepromSettings.RXChannel[NodeAddrByte] = getRXChannel(NodeAddrByte);
-        setSaveRequired();
         break;
 
       case CONTROL_FREQUENCY:
-
-        InString += (char)controlData[3];
-        InString += (char)controlData[4];
-        InString += (char)controlData[5];
-        InString += (char)controlData[6];
-        RXfrequencies[NodeAddr] = InString.toInt();
-        EepromSettings.RXfrequencies[NodeAddr] = RXfrequencies[NodeAddr];
-        setSaveRequired();
-        setModuleFrequency(RXfrequencies[NodeAddrByte], NodeAddrByte);
+        //  TODO: convert to band/freq?
         isConfigured = 1;
         break;
 
@@ -744,7 +735,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         //        }
         //addToSendQueue(SEND_SOUND_STATE);
         //playClickTones();
-        for (int i = 0; i < getNumReceivers(); i++) {
+        for (int i = 0; i < MAX_NUM_PILOTS; i++) {
           SendSoundMode(i);
         }
         isConfigured = 1;
@@ -766,7 +757,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         valueToSet = TO_BYTE(controlData[3]);
         uint8_t node = TO_BYTE(controlData[1]);
         // Skip this if we get an invalid node id
-        if(node >= MAX_NUM_RECEIVERS) {
+        if(node >= MAX_NUM_PILOTS) {
           break;
         }
         if (!raceMode) { // don't run threshold setup in race mode because we don't calculate slowRssi in race mode, but it's needed for setup threshold algorithm
@@ -807,7 +798,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         SendMinLap(NodeAddrByte);
         break;
       case CONTROL_SOUND:
-        for (int i = 0; i < getNumReceivers(); i++) {
+        for (int i = 0; i < MAX_NUM_PILOTS; i++) {
           SendSoundMode(i);
         }
         break;
@@ -816,7 +807,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         break;
       case CONTROL_GET_RSSI: // get current RSSI value
         //Serial.println("sending current RSSI");
-        for (int i = 0; i < getNumReceivers(); i++) {
+        for (int i = 0; i < MAX_NUM_PILOTS; i++) {
           SendCurrRSSI(i);
         }
         break;
@@ -846,7 +837,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
 }
 
 void thresholdModeStep() {
-  for(uint8_t i = 0; i < MAX_NUM_RECEIVERS; ++i) {
+  for(uint8_t i = 0; i < MAX_NUM_PILOTS; ++i) {
     setupThreshold(RSSI_SETUP_NEXT_STEP, i);
   }
 }

--- a/ESP32LapTimer/src/Comms.cpp
+++ b/ESP32LapTimer/src/Comms.cpp
@@ -534,7 +534,7 @@ void SendVRxBand(uint8_t NodeAddr) {
   addToSendQueue('S');
   addToSendQueue(TO_HEX(NodeAddr));
   addToSendQueue(RESPONSE_BAND);
-  addToSendQueue(TO_HEX(getRXBandPilot(NodeAddr)));
+  addToSendQueue(TO_HEX(getPilotBand(NodeAddr)));
   addToSendQueue('\n');
   //SendVRxFreq(NodeAddr);
 
@@ -545,7 +545,7 @@ void SendVRxChannel(uint8_t NodeAddr) {
   addToSendQueue('S');
   addToSendQueue(TO_HEX(NodeAddr));
   addToSendQueue(RESPONSE_CHANNEL);
-  addToSendQueue(TO_HEX(getRXChannelPilot(NodeAddr)));
+  addToSendQueue(TO_HEX(getPilotChannel(NodeAddr)));
   addToSendQueue('\n');
   //SendVRxFreq(NodeAddr);
 
@@ -553,7 +553,7 @@ void SendVRxChannel(uint8_t NodeAddr) {
 
 void SendVRxFreq(uint8_t NodeAddr) {
   //Cmd Byte F
-  uint8_t index = getRXChannelPilot(NodeAddr) + (8 * getRXBandPilot(NodeAddr));
+  uint8_t index = getPilotChannel(NodeAddr) + (8 * getPilotBand(NodeAddr));
   uint16_t frequency = channelFreqTable[index];
 
   addToSendQueue('S');
@@ -709,7 +709,11 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         break;
 
       case CONTROL_FREQUENCY:
-        //  TODO: convert to band/freq?
+        InString += (char)controlData[3];
+        InString += (char)controlData[4];
+        InString += (char)controlData[5];
+        InString += (char)controlData[6];
+        setPilotFrequency(InString.toInt(), NodeAddrByte);
         isConfigured = 1;
         break;
 

--- a/ESP32LapTimer/src/Comms.cpp
+++ b/ESP32LapTimer/src/Comms.cpp
@@ -225,7 +225,7 @@ void SendMinLap(uint8_t NodeAddr) {
 }
 
 void SendIsModuleConfigured() {
-  for (int i = 0; i < MAX_NUM_PILOTS; i ++) {
+  for (int i = 0; i < getMaxPilots(); i ++) {
     addToSendQueue('S');
     addToSendQueue(TO_HEX(i));
     addToSendQueue(RESPONSE_IS_CONFIGURED);
@@ -269,7 +269,7 @@ void SendMillis() {
   uint8_t buf[8];
   longToHex(buf, CurrMillis);
 
-  for (int i = 0; i < MAX_NUM_PILOTS; i ++) {
+  for (int i = 0; i < getMaxPilots(); i ++) {
     addToSendQueue('S');
     addToSendQueue(TO_HEX(i));
     addToSendQueue(RESPONSE_TIME);
@@ -311,7 +311,7 @@ void SendCurrRSSIloop() {
     return;
   }
   if (millis() > rssiMonitorInterval + lastRSSIsent) {
-    for (int i = 0; i < MAX_NUM_PILOTS; i ++) {
+    for (int i = 0; i < getMaxPilots(); i ++) {
       SendCurrRSSI(i);
     }
   }
@@ -444,7 +444,7 @@ void IRAM_ATTR sendLap(uint8_t Lap, uint8_t NodeAddr) {
 
 void SendNumberOfnodes() {
     addToSendQueue('N');
-    addToSendQueue(TO_HEX(MAX_NUM_PILOTS));
+    addToSendQueue(TO_HEX(getMaxPilots()));
     addToSendQueue('\n');
 }
 
@@ -568,7 +568,7 @@ void SendVRxFreq(uint8_t NodeAddr) {
 
 void sendAPIversion() {
 
-  for (int i = 0; i < MAX_NUM_PILOTS; i++) {
+  for (int i = 0; i < getMaxPilots(); i++) {
     addToSendQueue('S');
     addToSendQueue(TO_HEX(i));
     addToSendQueue(RESPONSE_API_VERSION);
@@ -655,7 +655,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
 
 
   if (controlData[2] == CONTROL_GET_ALL_DATA) {
-    for (int i = 0; i < MAX_NUM_PILOTS; i++) {
+    for (int i = 0; i < getMaxPilots(); i++) {
       SendAllSettings(i);
       //delay(100);
     }
@@ -681,7 +681,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
       case CONTROL_RACE_MODE:
         valueToSet = TO_BYTE(controlData[3]);
         setRaceMode(valueToSet);
-        for (int i = 0; i < MAX_NUM_PILOTS; i++) {
+        for (int i = 0; i < getMaxPilots(); i++) {
           SendRaceMode(i);
         }
         isConfigured = 1;
@@ -739,7 +739,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         //        }
         //addToSendQueue(SEND_SOUND_STATE);
         //playClickTones();
-        for (int i = 0; i < MAX_NUM_PILOTS; i++) {
+        for (int i = 0; i < getMaxPilots(); i++) {
           SendSoundMode(i);
         }
         isConfigured = 1;
@@ -802,7 +802,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         SendMinLap(NodeAddrByte);
         break;
       case CONTROL_SOUND:
-        for (int i = 0; i < MAX_NUM_PILOTS; i++) {
+        for (int i = 0; i < getMaxPilots(); i++) {
           SendSoundMode(i);
         }
         break;
@@ -811,7 +811,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
         break;
       case CONTROL_GET_RSSI: // get current RSSI value
         //Serial.println("sending current RSSI");
-        for (int i = 0; i < MAX_NUM_PILOTS; i++) {
+        for (int i = 0; i < getMaxPilots(); i++) {
           SendCurrRSSI(i);
         }
         break;
@@ -841,7 +841,7 @@ void handleSerialControlInput(char *controlData, uint8_t  ControlByte, uint8_t N
 }
 
 void thresholdModeStep() {
-  for(uint8_t i = 0; i < MAX_NUM_PILOTS; ++i) {
+  for(uint8_t i = 0; i < getMaxPilots(); ++i) {
     setupThreshold(RSSI_SETUP_NEXT_STEP, i);
   }
 }

--- a/ESP32LapTimer/src/ESP32LapTimer.cpp
+++ b/ESP32LapTimer/src/ESP32LapTimer.cpp
@@ -63,13 +63,20 @@ void IRAM_ATTR adc_task(void* args) {
   watchdog_add_task();
   while(42) {
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-    nbADCread(NULL);
+    if(LIKELY(!isCalibrating())) {
+      nbADCread(NULL);
+    } else {
+      rssiCalibrationUpdate();
+    }
     watchdog_feed();
   }
 }
 
 void setup() {
   init_crash_detection();
+  InitSPI();
+  InitHardwarePins();
+  RXPowerDownAll(); // Powers down all RX5808's
 
   Serial.begin(115200);
   Serial.println("Booting....");
@@ -87,15 +94,19 @@ void setup() {
 #ifdef USE_BUTTONS
   newButtonSetup();
 #endif
+  resetLaptimes();
 
   EepromSettings.setup();
+  setRXADCfilter(EepromSettings.RXADCfilter);
+  setADCVBATmode(EepromSettings.ADCVBATmode);
+  setVbatCal(EepromSettings.VBATcalibration);
 
-  delay(500);
-  InitHardwarePins();
+  for(int i = 0; i < MAX_NUM_PILOTS; ++i) {
+    setRXBandPilot(i, EepromSettings.RXBand[i]);
+    setRXChannelPilot(i, EepromSettings.RXChannel[i]);
+  }
+  delay(30);
   ConfigureADC();
-
-  InitSPI();
-  //PowerDownAll(); // Powers down all RX5808's
   delay(250);
 
   InitWifi();
@@ -107,30 +118,26 @@ void setup() {
     Serial.println("Detected That EEPROM corruption has occured.... \n Resetting EEPROM to Defaults....");
   }
 
-  setRXADCfilter(EepromSettings.RXADCfilter);
-  setADCVBATmode(EepromSettings.ADCVBATmode);
-  setVbatCal(EepromSettings.VBATcalibration);
   commsSetup();
-  init_outputs();
 
-  for (int i = 0; i < getNumReceivers(); i++) {
+  for (int i = 0; i < MAX_NUM_PILOTS; i++) {
     setRSSIThreshold(i, EepromSettings.RSSIthresholds[i]);
   }
+
+  // inits modules with defaults.  Loops 10 times  because some Rx modules dont initiate correctly.
+  for (int i = 0; i < getNumReceivers()*10; i++) {
+    setModuleChannelBand(i % getNumReceivers());
+    delayMicroseconds(MIN_TUNE_TIME_US);
+  }
+  
+  init_outputs();
+  Serial.println("Starting ADC reading task on core 0");
 
   xTaskCreatePinnedToCore(adc_task, "ADCreader", 4096, NULL, 1, &adc_task_handle, 0);
   hw_timer_t* adc_task_timer = timerBegin(0, 8, true);
   timerAttachInterrupt(adc_task_timer, &adc_read, true);
   timerAlarmWrite(adc_task_timer, 1667, true); // 6khz -> 1khz per adc channel
   timerAlarmEnable(adc_task_timer);
-
-  //SelectivePowerUp();
-
-  // inits modules with defaults.  Loops 10 times  because some Rx modules dont initiate correctly.
-  for (int i = 0; i < getNumReceivers()*10; i++) {
-    setModuleChannelBand(i % getNumReceivers());
-  }
-
-  //beep();
 }
 
 void loop() {
@@ -142,13 +149,6 @@ void loop() {
     reset_crash_count();
   }
   rssiCalibrationUpdate();
-  // touchMonitor(); // A function to monitor capacitive touch values, defined in buttons.ino
-
-  //  if (shouldReboot) {  //checks if reboot is needed
-  //    Serial.println("Rebooting...");
-  //    delay(100);
-  //    ESP.restart();
-  //  }
 #ifdef USE_BUTTONS
   newButtonUpdate();
 #endif

--- a/ESP32LapTimer/src/ESP32LapTimer.cpp
+++ b/ESP32LapTimer/src/ESP32LapTimer.cpp
@@ -101,10 +101,6 @@ void setup() {
   setADCVBATmode(EepromSettings.ADCVBATmode);
   setVbatCal(EepromSettings.VBATcalibration);
 
-  for(int i = 0; i < MAX_NUM_PILOTS; ++i) {
-    setRXBandPilot(i, EepromSettings.RXBand[i]);
-    setRXChannelPilot(i, EepromSettings.RXChannel[i]);
-  }
   delay(30);
   ConfigureADC();
   delay(250);
@@ -129,7 +125,7 @@ void setup() {
     setModuleChannelBand(i % getNumReceivers());
     delayMicroseconds(MIN_TUNE_TIME_US);
   }
-  
+
   init_outputs();
   Serial.println("Starting ADC reading task on core 0");
 

--- a/ESP32LapTimer/src/Filter.cpp
+++ b/ESP32LapTimer/src/Filter.cpp
@@ -1,0 +1,21 @@
+#include "Filter.h"
+
+#include <Arduino.h>
+
+#ifndef MATH_PI
+#define MATH_PI 3.14159
+#endif
+
+void filter_init(lowpass_filter_t* filter, float cutoff, float dt) {
+  filter->RC = 1 / (2 * MATH_PI * cutoff);
+  filter->alpha = dt / (filter->RC + dt);
+}
+float IRAM_ATTR filter_add_value(lowpass_filter_t* filter, float value) {
+  // y[i] := y[i-1] + α * (x[i] - y[i-1])
+  filter->state =  filter->state + filter->alpha * (value - filter->state);
+  return filter->state;
+}
+
+void filter_adjust_dt(lowpass_filter_t* filter, float dt) {
+  filter->alpha = dt / (filter->RC + dt);
+}

--- a/ESP32LapTimer/src/Filter.h
+++ b/ESP32LapTimer/src/Filter.h
@@ -15,135 +15,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#pragma once
+#ifndef __FILTER_H__
+#define __FILTER_H__
 
-//http://www.schwietering.com/jayduino/filtuino/index.php
+#include <stdint.h>
 
+// see https://en.wikipedia.org/wiki/Low-pass_filter#Simple_infinite_impulse_response_filter for reference
+typedef struct lowpass_filter_s {
+  float state;
+  float RC;
+  float alpha;
+  uint32_t last_call;
+  
+} lowpass_filter_t; 
 
-//Low pass bessel filter order=2 alpha1=0.01 
-class  FilterBeLp2_10HZ
-{
-  public:
-    FilterBeLp2_10HZ()
-    {
-      v[0]=0.0;
-      v[1]=0.0;
-    }
-  private:
-    float v[3];
-  public:
-    float step(float x) //class II 
-    {
-      v[0] = v[1];
-      v[1] = v[2];
-      v[2] = (1.492279154364811733e-3 * x)
-         + (-0.87068345511128286685 * v[0])
-         + (1.86471433849382361991 * v[1]);
-      return 
-         (v[0] + v[2])
-        +2 * v[1];
-    }
-};
+void filter_init(lowpass_filter_t* filter, float cutoff, float dt);
+void filter_adjust_dt(lowpass_filter_t* filter, float dt);
+float filter_add_value(lowpass_filter_t* filter, float value);
 
 
-//Low pass bessel filter order=2 alpha1=0.02, ie 20hz at 1000hz sample rate
-class FilterBeLp2_20HZ
-{
-  public:
-    FilterBeLp2_20HZ()
-    {
-      v[0] = 0.0;
-      v[1] = 0.0;
-    }
-  private:
-    double v[3];
-  public:
-    double step(double x) //class II
-    {
-      v[0] = v[1];
-      v[1] = v[2];
-      v[2] = (5.593440209108096160e-3 * x)
-             + (-0.75788377219702429688 * v[0])
-             + (1.73551001136059190877 * v[1]);
-      return
-        (v[0] + v[2])
-        + 2 * v[1];
-    }
-};
-
-//Low pass bessel filter order=2 alpha1=0.05 
-class  FilterBeLp2_50HZ
-{
-  public:
-    FilterBeLp2_50HZ()
-    {
-      v[0]=0.0;
-      v[1]=0.0;
-    }
-  private:
-    float v[3];
-  public:
-    float step(float x) //class II 
-    {
-      v[0] = v[1];
-      v[1] = v[2];
-      v[2] = (2.921062558939069298e-2 * x)
-         + (-0.49774398476624526211 * v[0])
-         + (1.38090148240868249019 * v[1]);
-      return 
-         (v[0] + v[2])
-        +2 * v[1];
-    }
-};
-
-
-//Low pass bessel filter order=2 alpha1=0.1 
-class  FilterBeLp2_100HZ
-{
-  public:
-    FilterBeLp2_100HZ()
-    {
-      v[0]=0.0;
-      v[1]=0.0;
-    }
-  private:
-    float v[3];
-  public:
-    float step(float x) //class II 
-    {
-      v[0] = v[1];
-      v[1] = v[2];
-      v[2] = (9.053999669813994622e-2 * x)
-         + (-0.24114073878907091308 * v[0])
-         + (0.87898075199651115597 * v[1]);
-      return 
-         (v[0] + v[2])
-        +2 * v[1];
-    }
-};
-
-
-//Low pass bessel filter order=2 alpha1=0.0002
-class FilterBeLp2Slow
-{
-  public:
-    FilterBeLp2Slow()
-    {
-      v[0] = 0.0;
-      v[1] = 0.0;
-    }
-  private:
-    double v[3];
-  public:
-    double step(double x) //class II
-    {
-      v[0] = v[1];
-      v[1] = v[2];
-      v[2] = (6.378909348514483213e-7 * x)
-             + (-0.99723520262946085957 * v[0])
-             + (1.99723265106572145378 * v[1]);
-      return
-        (v[0] + v[2])
-        + 2 * v[1];
-    }
-};
+#endif // __FILTER_H__

--- a/ESP32LapTimer/src/HardwareConfig.h
+++ b/ESP32LapTimer/src/HardwareConfig.h
@@ -67,8 +67,10 @@
 
 #define EEPROM_VERSION_NUMBER 9 // Increment when eeprom struct modified
 #define MAX_NUM_RECEIVERS 6
+#define MAX_NUM_PILOTS 8
+#define MULTIPLEX_STAY_TIME_US (5 * 1000)
 #define VOLTAGE_UPDATE_INTERVAL_MS 1000 // interval of the battery voltage reading
-#define MIN_TUNE_TIME 30000 // value in micro seconds
+#define MIN_TUNE_TIME_US 30000
 #define MAX_UDP_CLIENTS 5
 #define MAX_TCP_CLIENTS 5
 #define MAX_LAPS_NUM 100 // Maximum number of supported laps per pilot

--- a/ESP32LapTimer/src/HardwareConfig.h
+++ b/ESP32LapTimer/src/HardwareConfig.h
@@ -63,6 +63,9 @@
 // Enables the ArduinoOTA service. It allows flashing over WiFi and enters an emergency mode if a crashloop is detected.
 //#define USE_ARDUINO_OTA
 
+// Enables multiplexing. This causes the timer to always report 8 possible pilots and the client must support protocol v6
+//#define USE_MULTIPLEXING
+
 // BELOW ARE THE ADVANCED SETTINGS! ONLY CHANGE THEM IF YOU KNOW WHAT YOUR ARE DOING!
 
 #define EEPROM_VERSION_NUMBER 9 // Increment when eeprom struct modified

--- a/ESP32LapTimer/src/Laptime.cpp
+++ b/ESP32LapTimer/src/Laptime.cpp
@@ -24,22 +24,21 @@
 #include "settings_eeprom.h"
 #include "Comms.h"
 
-static volatile uint32_t LapTimes[MAX_NUM_RECEIVERS][MAX_LAPS_NUM];
-static volatile int lap_counter[MAX_NUM_RECEIVERS] = {0, 0, 0, 0, 0, 0}; //Keep track of what lap we are up too
-static int last_lap_sent[MAX_NUM_RECEIVERS];
+static uint32_t LapTimes[MAX_NUM_PILOTS][MAX_LAPS_NUM];
+static uint8_t lap_counter[MAX_NUM_PILOTS]; //Keep track of what lap we are up too
+static int last_lap_sent[MAX_NUM_PILOTS];
 
 static uint32_t MinLapTime = 5000;  //this is in millis
 static uint32_t start_time = 0;
 
 void resetLaptimes() {
-  for (int i = 0; i < getNumReceivers(); ++i) {
-    lap_counter[i] = 0;
-    last_lap_sent[i] = 0;
-  }
+  memset(LapTimes, 0, MAX_NUM_PILOTS * MAX_LAPS_NUM * sizeof(LapTimes[0][0]));
+  memset(lap_counter, 0, MAX_NUM_PILOTS * sizeof(lap_counter[0]));
+  memset(last_lap_sent, 0, MAX_NUM_PILOTS * sizeof(last_lap_sent[0]));
 }
 
 void sendNewLaps() {
-  for (int i = 0; i < getNumReceivers(); ++i) {
+  for (int i = 0; i < MAX_NUM_PILOTS; ++i) {
     int laps_to_send = lap_counter[i] - last_lap_sent[i];
     if(laps_to_send > 0) {
       for(int j = 0; j < laps_to_send; ++j) {
@@ -51,7 +50,10 @@ void sendNewLaps() {
 }
 
 uint32_t getLaptime(uint8_t receiver, uint8_t lap) {
-  return LapTimes[receiver][lap];
+  if(receiver < MAX_NUM_PILOTS && lap < MAX_LAPS_NUM) {
+    return LapTimes[receiver][lap];
+  }
+  return 0;
 }
 
 uint32_t getLaptime(uint8_t receiver) {

--- a/ESP32LapTimer/src/OLED.cpp
+++ b/ESP32LapTimer/src/OLED.cpp
@@ -157,14 +157,14 @@ void rx_page_input(void* data, uint8_t index, uint8_t type) {
 void rx_page_update(void* data) {
   // Gather Data
   rxPageData_s* my_data = (rxPageData_s*) data;
-  uint8_t frequencyIndex = getRXChannelPilot(my_data->currentPilotNumber) + (8 * getRXBandPilot(my_data->currentPilotNumber));
+  uint8_t frequencyIndex = getPilotChannel(my_data->currentPilotNumber) + (8 * getPilotBand(my_data->currentPilotNumber));
   uint16_t frequency = channelFreqTable[frequencyIndex];
 
   // Display things
   display.setTextAlignment(TEXT_ALIGN_LEFT);
   display.setFont(ArialMT_Plain_16);
   display.drawString(0, 0, "Settings for RX" + String(my_data->currentPilotNumber + 1));
-  display.drawString(0, 18, getBandLabel(getRXBandPilot(my_data->currentPilotNumber)) + String(getRXChannelPilot(my_data->currentPilotNumber) + 1) + " - " + frequency);
+  display.drawString(0, 18, getBandLabel(getPilotBand(my_data->currentPilotNumber)) + String(getPilotChannel(my_data->currentPilotNumber) + 1) + " - " + frequency);
   if (getRSSI(my_data->currentPilotNumber) < 600) {
     display.drawProgressBar(48, 35, 120 - 42, 8, map(600, 600, 3500, 0, 85));
   } else {
@@ -241,7 +241,7 @@ void summary_page_update(void* data) {
   uint8_t first_pilot = my_data->first_pilot;
   for (uint8_t i = 0; i < SUMMARY_PILOTS_PER_PAGE + skipped && (i + first_pilot) < MAX_NUM_PILOTS; ++i) {
     if(isPilotActive(i+first_pilot)) {
-      display.drawString(0, 9 + (i - skipped) * 9, String(i+1+first_pilot) + ":" + getBandLabel(getRXBandPilot(i + first_pilot)) + String(getRXChannelPilot(i + first_pilot) + 1) + "," + String(getRSSI(i + first_pilot) / 12));
+      display.drawString(0, 9 + (i - skipped) * 9, String(i+1+first_pilot) + ":" + getBandLabel(getPilotBand(i + first_pilot)) + String(getPilotChannel(i + first_pilot) + 1) + "," + String(getRSSI(i + first_pilot) / 12));
       display.drawProgressBar(RSSI_BAR_X_OFFSET, 10 + (i - skipped) * 9, RSSI_BAR_LENGTH, RSSI_BAR_HEIGHT, map(getRSSI(i + first_pilot), RSSI_ADC_READING_MIN, RSSI_ADC_READING_MAX, 0, 100));
       display.drawVerticalLine(RSSI_BAR_X_OFFSET + map(MAX(getRSSIThreshold(i + first_pilot), RSSI_ADC_READING_MIN), RSSI_ADC_READING_MIN, RSSI_ADC_READING_MAX, 0, RSSI_BAR_LENGTH),  10 + (i - skipped) * 9, RSSI_BAR_HEIGHT); // line to show the RSSIthresholds
     }
@@ -309,23 +309,23 @@ void airplane_page_input(void* data, uint8_t index, uint8_t type) {
 }
 
 void incrementRxFrequency(uint8_t currentRXNumber) {
-  uint8_t currentRXChannel = getRXChannelPilot(currentRXNumber);
+  uint8_t currentRXChannel = getPilotChannel(currentRXNumber);
   currentRXChannel++;
   if (currentRXChannel >= 8) {
     currentRXChannel = 0;
   }
-  setRXChannelPilot(currentRXNumber, currentRXChannel);
-  EepromSettings.RXChannel[currentRXNumber] = getRXChannelPilot(currentRXNumber);
+  setPilotChannel(currentRXNumber, currentRXChannel);
+  EepromSettings.RXChannel[currentRXNumber] = getPilotChannel(currentRXNumber);
   setSaveRequired();
 }
 void incrementRxBand(uint8_t currentRXNumber) {
-  uint8_t currentRXBand = getRXBandPilot(currentRXNumber);
+  uint8_t currentRXBand = getPilotBand(currentRXNumber);
   currentRXBand++;
   if (currentRXBand >= 8) {
     currentRXBand = 0;
   }
-  setRXBandPilot(currentRXNumber, currentRXBand);
-  EepromSettings.RXBand[currentRXNumber] = getRXBandPilot(currentRXNumber);
+  setPilotBand(currentRXNumber, currentRXBand);
+  EepromSettings.RXBand[currentRXNumber] = getPilotBand(currentRXNumber);
   setSaveRequired();
 }
 

--- a/ESP32LapTimer/src/OLED.cpp
+++ b/ESP32LapTimer/src/OLED.cpp
@@ -27,7 +27,10 @@
 #include "RX5808.h"
 #include "Calibration.h"
 #include "TimerWebServer.h"
+#include "Filter.h"
 #include "Utils.h"
+
+#define SUMMARY_PILOTS_PER_PAGE 6
 
 static uint8_t oledRefreshTime = 50;
 static uint32_t last_input_ms = 0;
@@ -48,11 +51,18 @@ static struct rxPageData_s {
   uint8_t currentPilotNumber;
 } rxPageData;
 
+static struct adcPageData_s {
+  lowpass_filter_t filter;
+} adcPageData;
+
+static struct summaryPageData_s {
+  uint8_t first_pilot;
+} summaryPageData;
 
 
 oled_page_t oled_pages[] = {
-  {NULL, NULL, summary_page_update, next_page_input},
-  {NULL, NULL, adc_page_update, next_page_input},
+  {&summaryPageData, summary_page_init, summary_page_update, summary_page_input},
+  {&adcPageData, adc_page_init, adc_page_update, next_page_input},
   {NULL, NULL, calib_page_update, calib_page_input},
   {NULL, NULL, airplane_page_update, airplane_page_input},
   {&rxPageData, rx_page_init, rx_page_update, rx_page_input}
@@ -73,7 +83,7 @@ void oledSetup(void) {
   display.drawFastImage(0, 0, 128, 64, ChorusLaptimerLogo_Screensaver);
   display.display();
   display.setFont(Dialog_plain_9);
-  
+
   for(uint8_t i = 0; i < NUM_OLED_PAGES; ++i) {
     if(oled_pages[i].init) {
       oled_pages[i].init(oled_pages[i].data);
@@ -131,7 +141,7 @@ void rx_page_input(void* data, uint8_t index, uint8_t type) {
   rxPageData_s* my_data = (rxPageData_s*) data;
   if(index == 0 && type == BUTTON_SHORT) {
     ++my_data->currentPilotNumber;
-    if(my_data->currentPilotNumber >= getNumReceivers()) {
+    if(my_data->currentPilotNumber >= MAX_NUM_PILOTS) {
       oledNextPage();
       my_data->currentPilotNumber = 0;
     }
@@ -147,14 +157,14 @@ void rx_page_input(void* data, uint8_t index, uint8_t type) {
 void rx_page_update(void* data) {
   // Gather Data
   rxPageData_s* my_data = (rxPageData_s*) data;
-  uint8_t frequencyIndex = getRXChannel(my_data->currentPilotNumber) + (8 * getRXBand(my_data->currentPilotNumber));
+  uint8_t frequencyIndex = getRXChannelPilot(my_data->currentPilotNumber) + (8 * getRXBandPilot(my_data->currentPilotNumber));
   uint16_t frequency = channelFreqTable[frequencyIndex];
 
   // Display things
   display.setTextAlignment(TEXT_ALIGN_LEFT);
   display.setFont(ArialMT_Plain_16);
   display.drawString(0, 0, "Settings for RX" + String(my_data->currentPilotNumber + 1));
-  display.drawString(0, 18, getBandLabel(getRXBand(my_data->currentPilotNumber)) + String(getRXChannel(my_data->currentPilotNumber) + 1) + " - " + frequency);
+  display.drawString(0, 18, getBandLabel(getRXBandPilot(my_data->currentPilotNumber)) + String(getRXChannelPilot(my_data->currentPilotNumber) + 1) + " - " + frequency);
   if (getRSSI(my_data->currentPilotNumber) < 600) {
     display.drawProgressBar(48, 35, 120 - 42, 8, map(600, 600, 3500, 0, 85));
   } else {
@@ -167,7 +177,26 @@ void rx_page_update(void* data) {
   display.drawString(0,55, "Btn2 LONG  - Band.");
 }
 
-void summary_page_update(void* data) {
+void summary_page_init(void* data) {
+  summaryPageData_s* my_data = (summaryPageData_s*) data;
+  my_data->first_pilot = 0;
+}
+
+void summary_page_input(void* data, uint8_t index, uint8_t type) {
+  summaryPageData_s* my_data = (summaryPageData_s*) data;
+  if(index == 1 && type == BUTTON_SHORT) {
+    if(my_data->first_pilot + SUMMARY_PILOTS_PER_PAGE >= getActivePilots()) {
+      my_data->first_pilot = 0;
+    } else {
+      my_data->first_pilot += MIN(SUMMARY_PILOTS_PER_PAGE, getActivePilots() - SUMMARY_PILOTS_PER_PAGE);
+    }
+  }
+  else {
+    next_page_input(data, index, type);
+  }
+}
+
+void draw_header() {
   // Display on time
   display.setTextAlignment(TEXT_ALIGN_LEFT);
   // Hours
@@ -198,22 +227,40 @@ void summary_page_update(void* data) {
   if (getADCVBATmode() == INA219) {
     display.drawString(90, 0, String(getMaFloat()/1000, 2) + "A");
   }
-  
+}
+
+void summary_page_update(void* data) {
+  summaryPageData_s* my_data = (summaryPageData_s*) data;
+  draw_header();
   // Rx modules
   display.setTextAlignment(TEXT_ALIGN_LEFT);
   #define RSSI_BAR_LENGTH (127 - 42)
   #define RSSI_BAR_HEIGHT 8
   #define RSSI_BAR_X_OFFSET 40
-  for (int i = 0; i < getNumReceivers(); i++) {
-    display.drawString(0, 9 + i * 9, getBandLabel(getRXBand(i)) + String(getRXChannel(i) + 1) + ", " + String(getRSSI(i) / 12));
-    display.drawProgressBar(RSSI_BAR_X_OFFSET, 10 + i * 9, RSSI_BAR_LENGTH, RSSI_BAR_HEIGHT, map(getRSSI(i), RSSI_ADC_READING_MIN, RSSI_ADC_READING_MAX, 0, 100));
-    display.drawVerticalLine(RSSI_BAR_X_OFFSET + map(MAX(getRSSIThreshold(i), RSSI_ADC_READING_MIN), RSSI_ADC_READING_MIN, RSSI_ADC_READING_MAX, 0, RSSI_BAR_LENGTH),  10 + i * 9, RSSI_BAR_HEIGHT); // line to show the RSSIthresholds
+  uint8_t skipped = 0;
+  uint8_t first_pilot = my_data->first_pilot;
+  for (uint8_t i = 0; i < SUMMARY_PILOTS_PER_PAGE + skipped && (i + first_pilot) < MAX_NUM_PILOTS; ++i) {
+    if(isPilotActive(i+first_pilot)) {
+      display.drawString(0, 9 + (i - skipped) * 9, String(i+1+first_pilot) + ":" + getBandLabel(getRXBandPilot(i + first_pilot)) + String(getRXChannelPilot(i + first_pilot) + 1) + "," + String(getRSSI(i + first_pilot) / 12));
+      display.drawProgressBar(RSSI_BAR_X_OFFSET, 10 + (i - skipped) * 9, RSSI_BAR_LENGTH, RSSI_BAR_HEIGHT, map(getRSSI(i + first_pilot), RSSI_ADC_READING_MIN, RSSI_ADC_READING_MAX, 0, 100));
+      display.drawVerticalLine(RSSI_BAR_X_OFFSET + map(MAX(getRSSIThreshold(i + first_pilot), RSSI_ADC_READING_MIN), RSSI_ADC_READING_MIN, RSSI_ADC_READING_MAX, 0, RSSI_BAR_LENGTH),  10 + (i - skipped) * 9, RSSI_BAR_HEIGHT); // line to show the RSSIthresholds
+    }
+    else {
+      ++skipped;
+    }
   }
 }
 
+void adc_page_init(void* data) {
+  adcPageData_s* my_data = (adcPageData_s*)data;
+  filter_init(&my_data->filter, 1, oledRefreshTime/1000.0);
+}
+
 void adc_page_update(void* data) {
+  adcPageData_s* my_data = (adcPageData_s*)data;
   display.setTextAlignment(TEXT_ALIGN_LEFT);
-  display.drawString(0, 0, "ADC loop " + String(getADCLoopCount() * (1000.0 / oledRefreshTime)) + " Hz");
+  float freq = filter_add_value(&my_data->filter, getADCLoopCount() * (1000.0 / oledRefreshTime));
+  display.drawString(0, 0, "ADC loop " + String(freq) + " Hz");
   setADCLoopCount(0);
   display.drawString(0, 9, String(getMaFloat()) + " mA");
 }
@@ -232,7 +279,7 @@ void calib_page_update(void* data) {
 void calib_page_input(void* data, uint8_t index, uint8_t type) {
   (void)data;
   if(index == 1 && type == BUTTON_SHORT) {
-    rssiCalibration();  
+    rssiCalibration();
   }
   else {
     next_page_input(data, index, type);
@@ -262,27 +309,24 @@ void airplane_page_input(void* data, uint8_t index, uint8_t type) {
 }
 
 void incrementRxFrequency(uint8_t currentRXNumber) {
-  uint8_t currentRXChannel = getRXChannel(currentRXNumber);
-  uint8_t currentRXBand = getRXBand(currentRXNumber);
+  uint8_t currentRXChannel = getRXChannelPilot(currentRXNumber);
   currentRXChannel++;
   if (currentRXChannel >= 8) {
-    //currentRXBand++;
     currentRXChannel = 0;
   }
-  if (currentRXBand >= 7 && currentRXChannel >= 2) {
-    currentRXBand = 0;
-    currentRXChannel = 0;
-  }
-  setModuleChannelBand(currentRXChannel,currentRXBand,currentRXNumber);
+  setRXChannelPilot(currentRXNumber, currentRXChannel);
+  EepromSettings.RXChannel[currentRXNumber] = getRXChannelPilot(currentRXNumber);
+  setSaveRequired();
 }
 void incrementRxBand(uint8_t currentRXNumber) {
-  uint8_t currentRXChannel = getRXChannel(currentRXNumber);
-  uint8_t currentRXBand = getRXBand(currentRXNumber);
+  uint8_t currentRXBand = getRXBandPilot(currentRXNumber);
   currentRXBand++;
   if (currentRXBand >= 8) {
     currentRXBand = 0;
   }
-  setModuleChannelBand(currentRXChannel,currentRXBand,currentRXNumber);
+  setRXBandPilot(currentRXNumber, currentRXBand);
+  EepromSettings.RXBand[currentRXNumber] = getRXBandPilot(currentRXNumber);
+  setSaveRequired();
 }
 
 void setDisplayScreenNumber(uint16_t num) {

--- a/ESP32LapTimer/src/OLED.h
+++ b/ESP32LapTimer/src/OLED.h
@@ -43,7 +43,12 @@ void rx_page_input(void* data, uint8_t index, uint8_t type);
 void rx_page_init(void* data);
 
 void summary_page_update(void* data);
+void summary_page_init(void* data);
+void summary_page_input(void* data, uint8_t index, uint8_t type);
+
 void adc_page_update(void* data);
+void adc_page_init(void* data);
+
 void calib_page_update(void* data);
 void calib_page_input(void* data, uint8_t index, uint8_t type);
 

--- a/ESP32LapTimer/src/Queue.c
+++ b/ESP32LapTimer/src/Queue.c
@@ -1,0 +1,54 @@
+#include "Queue.h"
+
+#include <esp_attr.h>
+#include <string.h>
+
+void queue_init(queue_t* queue, void** data, uint32_t max_size) {
+  queue->curr_size = 0;
+  queue->data = data;
+  queue->max_size = max_size;
+}
+
+int queue_empty(queue_t* queue){
+  return queue->curr_size != 0;
+}
+
+void* queue_get(queue_t* queue, uint32_t index) {
+  if(index < queue->curr_size) {
+    return queue->data[index];
+  }
+  return NULL;
+}
+
+void* IRAM_ATTR queue_peek(queue_t* queue) {
+  if(queue == NULL){
+    return NULL;
+  }
+  if(queue->curr_size == 0) {
+    return NULL;
+  }
+  void* data = queue->data[0];
+  return data;
+}
+
+void* IRAM_ATTR queue_dequeue(queue_t* queue){
+  void* data = queue_peek(queue);
+  if(data) {
+    --queue->curr_size;
+    memmove(queue->data, queue->data + 1, sizeof(void*) * queue->curr_size);
+  }
+  return data;
+}
+
+
+int IRAM_ATTR queue_enqueue(queue_t* queue, void* data){
+  if(queue == NULL){
+    return -1;
+  }
+  if(queue->curr_size + 1 > queue->max_size) {
+    return QUEUE_ERROR_FULL;
+  }
+  queue->data[queue->curr_size] = data;
+  queue->curr_size += 1;
+  return 0;
+}

--- a/ESP32LapTimer/src/Queue.h
+++ b/ESP32LapTimer/src/Queue.h
@@ -1,0 +1,31 @@
+#ifndef __QUEUE_H__
+#define __QUEUE_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#define QUEUE_ERROR_FULL -2
+#define QUEUE_ERROR_EMPTY -3
+
+typedef struct queue_s{
+  void** data;
+  uint8_t curr_size;
+  uint32_t max_size;
+} queue_t;
+
+void queue_init(queue_t* queue, void** data, uint32_t max_size);
+int queue_empty(queue_t* queue);
+void* queue_get(queue_t* queue, uint32_t index);
+void* queue_dequeue(queue_t* queue);
+int queue_enqueue(queue_t* queue, void* data);
+void* queue_peek(queue_t* queue);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __QUEUE_H__

--- a/ESP32LapTimer/src/RX5808.cpp
+++ b/ESP32LapTimer/src/RX5808.cpp
@@ -39,10 +39,6 @@
 static volatile uint8_t RXBandModule[MAX_NUM_RECEIVERS];
 static volatile uint8_t RXChannelModule[MAX_NUM_RECEIVERS];
 
-// TODO: this doesn't really belong here
-static volatile uint8_t RXBandPilot[MAX_NUM_PILOTS];
-static volatile uint8_t RXChannelPilot[MAX_NUM_PILOTS];
-
 static uint32_t lastUpdate[MAX_NUM_RECEIVERS] = {0,0,0,0,0,0};
 
 void InitSPI() {
@@ -178,7 +174,7 @@ uint16_t setModuleChannelBand(uint8_t NodeAddr) {
   return setModuleChannelBand(RXChannelModule[NodeAddr], RXBandModule[NodeAddr], NodeAddr);
 }
 
-uint16_t setModuleChannelBand(uint8_t channel, uint8_t band, uint8_t NodeAddr) {  
+uint16_t setModuleChannelBand(uint8_t channel, uint8_t band, uint8_t NodeAddr) {
   uint8_t index = channel + (8 * band);
   uint16_t frequency = channelFreqTable[index];
   RXBandModule[NodeAddr] = band;
@@ -228,22 +224,6 @@ String getBandLabel(int band) {
   }
 }
 
-void setRXBandPilot(uint8_t pilot, uint8_t band) {
-  RXBandPilot[pilot] = band;
-}
-uint8_t getRXBandPilot(uint8_t pilot) {
-  return RXBandPilot[pilot];
-}
-
-void setRXChannelPilot(uint8_t pilot, uint8_t channel) {
-  if(pilot < MAX_NUM_PILOTS) {
-    RXChannelPilot[pilot] = channel;
-  }
-}
-uint8_t getRXChannelPilot(uint8_t pilot) {
-  return RXChannelPilot[pilot];
-}
-
 void setRXBandModule(uint8_t module, uint8_t band) {
   RXBandModule[module] = band;
 }
@@ -257,3 +237,12 @@ void setRXChannelModule(uint8_t module, uint8_t channel) {
 uint8_t getRXChannelModule(uint8_t module) {
   return RXChannelModule[module];
 }
+
+uint16_t getFrequencyFromBandChannel(uint8_t band, uint8_t channel) {
+  uint16_t freq = 0;
+  if(band < MAX_BAND && channel < MAX_CHANNEL) {
+    freq = channelFreqTable[channel + (MAX_CHANNEL+1) * band];
+  }
+  return freq;
+}
+

--- a/ESP32LapTimer/src/RX5808.cpp
+++ b/ESP32LapTimer/src/RX5808.cpp
@@ -1,5 +1,5 @@
 /*
- * This file is part of Chorus32-ESP32LapTimer 
+ * This file is part of Chorus32-ESP32LapTimer
  * (see https://github.com/AlessandroAU/Chorus32-ESP32LapTimer).
  *
  * This program is free software: you can redistribute it and/or modify
@@ -66,6 +66,7 @@ void rxWrite(uint8_t addressBits, uint32_t dataBits, uint8_t CSpin) {
 
 void rxWriteNode(uint8_t node, uint8_t addressBits, uint32_t dataBits) {
   if (node < MAX_NUM_RECEIVERS) {
+    lastUpdate[node] = micros();
     rxWrite(addressBits, dataBits, CS_PINS[node]);
   }
 }
@@ -85,7 +86,7 @@ void rxWriteAll(uint8_t addressBits, uint32_t dataBits) {
     digitalWrite(CS_PINS[i], HIGH);
   }
 
-  delayMicroseconds(MIN_TUNE_TIME);
+  delayMicroseconds(MIN_TUNE_TIME_US);
 
   SPI.endTransaction();
 

--- a/ESP32LapTimer/src/RX5808.h
+++ b/ESP32LapTimer/src/RX5808.h
@@ -64,7 +64,6 @@ const uint16_t channelFreqTable[] = {
 //  // even more connex, last 6 unused!!!
 //};
 
-uint16_t setModuleChannel(uint8_t channel, uint8_t band);
 
 void InitSPI();
 void SetDefaultRegs();
@@ -74,12 +73,29 @@ uint16_t setModuleFrequencyAll(uint16_t frequency);
 uint16_t setModuleFrequency(uint16_t frequency, uint8_t NodeAddr);
 String getBandLabel(int band);
 
-void setRXBand(uint8_t node, uint8_t band);
-uint8_t getRXBand(uint8_t node);
+void setRXBandModule(uint8_t module, uint8_t band);
+uint8_t getRXBandModule(uint8_t module);
 
-void setRXChannel(uint8_t node, uint8_t channel);
-uint8_t getRXChannel(uint8_t node);
+void setRXChannelModule(uint8_t module, uint8_t channel);
+uint8_t getRXChannelModule(uint8_t module);
+
+void setRXBandPilot(uint8_t pilot, uint8_t band);
+uint8_t getRXBandPilot(uint8_t pilot);
+
+void setRXChannelPilot(uint8_t pilot, uint8_t channel);
+uint8_t getRXChannelPilot(uint8_t pilot);
 
 uint16_t getFrequencyFromBandChannel(uint8_t band, uint8_t channel);
+
+bool isRxReady(uint8_t module);
+
+void RXpowerOn(uint8_t NodeAddr);
+void RXstandBy(uint8_t NodeAddr);
+void RXPowerDown(uint8_t NodeAddr);
+void RXreset(uint8_t NodeAddr);
+void RXstandBy(uint8_t NodeAddr);
+void RXPowerUpAll();
+void RXPowerDownAll();
+void RXResetAll();
 
 #endif

--- a/ESP32LapTimer/src/RX5808.h
+++ b/ESP32LapTimer/src/RX5808.h
@@ -23,6 +23,7 @@
 #include <Arduino.h>
 
 #define MAX_BAND 7
+#define MAX_CHANNEL 7
 
 //// Channels to send to the SPI registers
 //const uint16_t channelTable[] PROGMEM = {
@@ -78,12 +79,6 @@ uint8_t getRXBandModule(uint8_t module);
 
 void setRXChannelModule(uint8_t module, uint8_t channel);
 uint8_t getRXChannelModule(uint8_t module);
-
-void setRXBandPilot(uint8_t pilot, uint8_t band);
-uint8_t getRXBandPilot(uint8_t pilot);
-
-void setRXChannelPilot(uint8_t pilot, uint8_t channel);
-uint8_t getRXChannelPilot(uint8_t pilot);
 
 uint16_t getFrequencyFromBandChannel(uint8_t band, uint8_t channel);
 

--- a/ESP32LapTimer/src/TimerWebServer.cpp
+++ b/ESP32LapTimer/src/TimerWebServer.cpp
@@ -92,11 +92,8 @@ bool handleFileRead(AsyncWebServerRequest* req, String path) { // send the right
 
 void updateRx (int band, int channel, int rx) {
   rx = rx - 1;
-  setModuleChannelBand(band, channel, rx);
-  EepromSettings.RXBand[rx] = band;
-  EepromSettings.RXChannel[rx] = channel;
-  uint16_t index = getRXChannel(rx) + (8 * getRXBand(rx));
-  EepromSettings.RXfrequencies[rx] = channelFreqTable[index];
+  setPilotBand(rx, band);
+  setPilotChannel(rx, channel);
 }
 
 void SendStatusVars(AsyncWebServerRequest* req) {
@@ -178,7 +175,7 @@ void ProcessGeneralSettingsUpdate(AsyncWebServerRequest* req) {
   String Rssi = req->arg("RSSIthreshold");
   int rssi = (byte)Rssi.toInt();
   int value = rssi * 12;
-  for (int i = 0 ; i < MAX_NUM_RECEIVERS; i++) {
+  for (int i = 0 ; i < MAX_NUM_PILOTS; i++) {
     EepromSettings.RSSIthresholds[i] = value;
     setRSSIThreshold(i, value);
   }

--- a/ESP32LapTimer/src/Watchdog.c
+++ b/ESP32LapTimer/src/Watchdog.c
@@ -23,11 +23,11 @@
 #include <esp_task_wdt.h>
 
 void watchdog_add_task() {
-	esp_task_wdt_add(NULL);
+  esp_task_wdt_add(NULL);
 }
 
 void watchdog_feed() {
-	TIMERG0.wdt_wprotect = TIMG_WDT_WKEY_VALUE;
-	TIMERG0.wdt_feed = 1;
-	TIMERG0.wdt_wprotect = 0;
+  TIMERG0.wdt_wprotect = TIMG_WDT_WKEY_VALUE;
+  TIMERG0.wdt_feed = 1;
+  TIMERG0.wdt_wprotect = 0;
 }

--- a/ESP32LapTimer/src/settings_eeprom.cpp
+++ b/ESP32LapTimer/src/settings_eeprom.cpp
@@ -187,6 +187,14 @@ uint8_t getNumReceivers() {
   return EepromSettings.NumReceivers;
 }
 
+uint8_t getMaxPilots() {
+#ifdef USE_MULTIPLEXING
+  return MAX_NUM_PILOTS;
+#else
+  return getNumReceivers();
+#endif
+}
+
 uint32_t getDisplayTimeout() {
   return EepromSettings.display_timeout_ms;
 }

--- a/ESP32LapTimer/src/settings_eeprom.cpp
+++ b/ESP32LapTimer/src/settings_eeprom.cpp
@@ -34,9 +34,6 @@ void EepromSettingsStruct::load() {
   EEPROM.get(0, *this);
   Serial.println("EEPROM LOADED");
 
-  Serial.println(EepromSettings.NumReceivers);
-  Serial.println(NumReceivers);
-
   if (this->eepromVersionNumber != EEPROM_VERSION_NUMBER) {
     this->defaults();
     Serial.println("EEPROM DEFAULTS LOADED");
@@ -49,9 +46,8 @@ bool EepromSettingsStruct::SanityCheck() {
 
   if (EepromSettings.NumReceivers > MAX_NUM_RECEIVERS) {
     IsGoodEEPROM = false;
-    Serial.print("Error: Corrupted EEPROM value NumRecievers: ");
+    Serial.print("Error: Corrupted EEPROM value getNumReceivers(): ");
     Serial.println(EepromSettings.NumReceivers);
-    return IsGoodEEPROM;
   }
 
 
@@ -59,65 +55,48 @@ bool EepromSettingsStruct::SanityCheck() {
     IsGoodEEPROM = false;
     Serial.print("Error: Corrupted EEPROM value RXADCfilter: ");
     Serial.println(EepromSettings.RXADCfilter);
-    return IsGoodEEPROM;
   }
 
   if (EepromSettings.ADCVBATmode > MaxVbatMode) {
     IsGoodEEPROM = false;
     Serial.print("Error: Corrupted EEPROM value ADCVBATmode: ");
     Serial.println(EepromSettings.ADCVBATmode);
-    return IsGoodEEPROM;
   }
 
   if (EepromSettings.VBATcalibration > MaxVBATCalibration) {
     IsGoodEEPROM = false;
     Serial.print("Error: Corrupted EEPROM value VBATcalibration: ");
     Serial.println(EepromSettings.VBATcalibration);
-    return IsGoodEEPROM;
   }
 
-  for (int i = 0; i < EepromSettings.NumReceivers; i++) {
+  for (int i = 0; i < MAX_NUM_PILOTS; i++) {
     if (EepromSettings.RXBand[i] > MaxBand) {
       IsGoodEEPROM = false;
       Serial.print("Error: Corrupted EEPROM NODE: ");
       Serial.print(i);
       Serial.print(" value MaxBand: ");
       Serial.println(EepromSettings.RXBand[i]);
-      return IsGoodEEPROM;
     }
 
   }
 
-  for (int i = 0; i < EepromSettings.NumReceivers; i++) {
+  for (int i = 0; i < MAX_NUM_PILOTS; i++) {
     if (EepromSettings.RXChannel[i] > MaxChannel) {
       IsGoodEEPROM = false;
       Serial.print("Error: Corrupted EEPROM NODE: ");
       Serial.print(i);
       Serial.print(" value RXChannel: ");
       Serial.println(EepromSettings.RXChannel[i]);
-      return IsGoodEEPROM;
     }
   }
 
-  for (int i = 0; i < EepromSettings.NumReceivers; i++) {
-    if ((EepromSettings.RXfrequencies[i] > MaxFreq) or (EepromSettings.RXfrequencies[i] < MinFreq)) {
-      IsGoodEEPROM = false;
-      Serial.print("Error: Corrupted EEPROM NODE: ");
-      Serial.print(i);
-      Serial.print(" value RXfrequencies: ");
-      Serial.println(EepromSettings.RXfrequencies[i]);
-      return IsGoodEEPROM;
-    }
-  }
-
-  for (int i = 0; i < EepromSettings.NumReceivers; i++) {
+  for (int i = 0; i < MAX_NUM_PILOTS; i++) {
     if (EepromSettings.RSSIthresholds[i] > MaxThreshold) {
       IsGoodEEPROM = false;
       Serial.print("Error: Corrupted EEPROM NODE: ");
       Serial.print(i);
       Serial.print(" value RSSIthresholds: ");
       Serial.println(EepromSettings.RSSIthresholds[i]);
-      return IsGoodEEPROM;
     }
   }
   return IsGoodEEPROM && this->validateCRC();
@@ -144,7 +123,6 @@ void EepromSettingsStruct::defaults() {
     settings.RSSIthresholds[i] = 2048;
     settings.RXBand[i] = 0;
     settings.RXChannel[i] = i % 8;
-    settings.RXfrequencies[i] = getFrequencyFromBandChannel(settings.RXBand[i], settings.RXChannel[i]);
   }
 
   settings.eepromVersionNumber = EEPROM_VERSION_NUMBER;

--- a/ESP32LapTimer/src/settings_eeprom.h
+++ b/ESP32LapTimer/src/settings_eeprom.h
@@ -36,10 +36,9 @@ enum ADCVBATmode_ {OFF, ADC_CH5, ADC_CH6, INA219};
 
 struct EepromSettingsStruct {
   uint16_t eepromVersionNumber;
-  uint8_t RXBand[MAX_NUM_RECEIVERS];
-  uint8_t RXChannel[MAX_NUM_RECEIVERS];
-  uint16_t RXfrequencies[MAX_NUM_RECEIVERS];
-  int RSSIthresholds[MAX_NUM_RECEIVERS];
+  uint8_t RXBand[MAX_NUM_PILOTS];
+  uint8_t RXChannel[MAX_NUM_PILOTS];
+  uint16_t RSSIthresholds[MAX_NUM_PILOTS];
   RXADCfilter_ RXADCfilter;
   ADCVBATmode_ ADCVBATmode;
   float VBATcalibration;

--- a/ESP32LapTimer/src/settings_eeprom.h
+++ b/ESP32LapTimer/src/settings_eeprom.h
@@ -38,6 +38,7 @@ struct EepromSettingsStruct {
   uint16_t eepromVersionNumber;
   uint8_t RXBand[MAX_NUM_PILOTS];
   uint8_t RXChannel[MAX_NUM_PILOTS];
+  uint16_t RXFrequency[MAX_NUM_PILOTS];
   uint16_t RSSIthresholds[MAX_NUM_PILOTS];
   RXADCfilter_ RXADCfilter;
   ADCVBATmode_ ADCVBATmode;

--- a/ESP32LapTimer/src/settings_eeprom.h
+++ b/ESP32LapTimer/src/settings_eeprom.h
@@ -74,6 +74,8 @@ int getWiFiChannel();
 int getWiFiProtocol();
 
 uint8_t getNumReceivers();
+uint8_t getMaxPilots();
+
 uint32_t getDisplayTimeout();
 
 void setSaveRequired();


### PR DESCRIPTION
This implements multiplexing and fixes #49 
Another way too large one, sorry! It might still contains a few unrelated changes, which need to be removed.

The most notable change is, that we have to differentiate between pilots and modules. 
All active pilots are pushed into a queue and if there is a pilot in the queue it gets assigned to a module if:
 * The module hasn't switched in MULTIPLEX_STAY_TIME_US + MIN_TUNE_TIME_US
 * The waiting client has been without a module for at least MULTIPLEX_STAY_TIME_US + MIN_TUNE_TIME_US
   * The intention is, that with 4 modules and 5 pilots we prevent switching of all modules

If no multiplexing is needed the queue is empty and only the initial assignment will occur.

This also powers down all unused modules if the number of activated pilots is less than the number of modules and allows any pilot combination to be activated with minimal module usage (for example enabling pilot 2 and 5 only powers module 1 and 2):
By default it enables as many pilots as modules are configured, so the default shouldn't change.

I experimented a little bit with filtering (like dynamically adjust the dt or use the average sampling rate), but I had the best result with just using the normal sampling frequency and just ignore the tune time.
In my first tests there was only a very minor difference when using a 2nd order bessel lowpass in comparison to a 1st order lowpass.

As my other modules are still on the way I was only able to test it with a single module installed.