### PR TITLE
Fix race condition in output

### DIFF
--- a/ESP32LapTimer/ADC.cpp
+++ b/ESP32LapTimer/ADC.cpp
@@ -136,8 +136,7 @@ void IRAM_ATTR CheckRSSIthresholdExceeded(uint8_t node) {
   uint32_t CurrTime = millis();
   if ( ADCvalues[node] > RSSIthresholds[node]) {
     if (CurrTime > (getMinLapTime() + getLaptime(node))) {
-      uint8_t lap_num = addLap(node, CurrTime);
-      sendLap(lap_num, node);
+      addLap(node, CurrTime);
     }
   }
 }

--- a/ESP32LapTimer/ESP32LapTimer.ino
+++ b/ESP32LapTimer/ESP32LapTimer.ino
@@ -23,6 +23,7 @@
 #include "WebServer.h"
 #include "Watchdog.h"
 #include "Utils.h"
+#include "Laptime.h"
 
 //#define BluetoothEnabled //uncomment this to use bluetooth (experimental, ble + wifi appears to cause issues)
 
@@ -124,6 +125,7 @@ void loop() {
 #ifdef OLED
   OLED_CheckIfUpdateReq();
 #endif
+  sendNewLaps();
   update_outputs();
   SendCurrRSSIloop();
   updateWifi();

--- a/ESP32LapTimer/Laptime.cpp
+++ b/ESP32LapTimer/Laptime.cpp
@@ -4,9 +4,11 @@
 
 #include "HardwareConfig.h"
 #include "settings_eeprom.h"
+#include "Comms.h"
 
 static volatile uint32_t LapTimes[MaxNumReceivers][MAX_LAPS_NUM];
 static volatile int lap_counter[MaxNumReceivers] = {0, 0, 0, 0, 0, 0}; //Keep track of what lap we are up too
+static int last_lap_sent[MaxNumReceivers];
 
 static uint32_t MinLapTime = 5000;  //this is in millis
 static uint32_t start_time = 0;
@@ -14,6 +16,19 @@ static uint32_t start_time = 0;
 void resetLaptimes() {
   for (int i = 0; i < getNumReceivers(); ++i) {
     lap_counter[i] = 0;
+    last_lap_sent[i] = 0;
+  }
+}
+
+void sendNewLaps() {
+  for (int i = 0; i < getNumReceivers(); ++i) {
+    int laps_to_send = lap_counter[i] - last_lap_sent[i];
+    if(laps_to_send > 0) {
+      for(int j = 0; j < laps_to_send; ++j) {
+        sendLap(lap_counter[i] - j, i);
+      }
+      last_lap_sent[i] += laps_to_send;
+    }
   }
 }
 

--- a/ESP32LapTimer/Laptime.h
+++ b/ESP32LapTimer/Laptime.h
@@ -22,4 +22,7 @@ uint8_t addLap(uint8_t receiver, uint32_t time);
 /// Laps begin at 1. lap 0 is always 0
 uint8_t getCurrentLap(uint8_t receiver);
 
+/// Sends unsent laps to the output queue
+void sendNewLaps();
+
 #endif // __LAPTIME_H__

--- a/ESP32LapTimer/Output.cpp
+++ b/ESP32LapTimer/Output.cpp
@@ -7,10 +7,14 @@
 #include "Bluetooth.h"
 #endif
 
+#include <freertos/semphr.h>
+
 #define MAX_OUTPUT_BUFFER_SIZE 1500
 
 static uint8_t output_buffer[MAX_OUTPUT_BUFFER_SIZE];
-static int output_buffer_pos = 0; //Keep track of where we are in the Que
+static int output_buffer_pos = 0; //Keep track of where we are in the Queue
+
+static SemaphoreHandle_t queue_semaphore = NULL;
 
 // TODO: define this somewhere else!
 static output_t outputs[] = {
@@ -25,14 +29,17 @@ static output_t outputs[] = {
 
 #define OUTPUT_SIZE (sizeof(outputs)/sizeof(outputs[0]))
 
-
 bool IRAM_ATTR addToSendQueue(uint8_t item) {
-  if(output_buffer_pos >= MAX_OUTPUT_BUFFER_SIZE) {
-    Serial.println("Output buffer full!");
-    return false;
+  if(xSemaphoreTake(queue_semaphore, portMAX_DELAY)) {
+    if(output_buffer_pos >= MAX_OUTPUT_BUFFER_SIZE) {
+      xSemaphoreGive(queue_semaphore);
+      return false;
+    }
+    output_buffer[output_buffer_pos++] = item;
+    xSemaphoreGive(queue_semaphore);
+    return true;
   }
-  output_buffer[output_buffer_pos++] = item;
-  return true;
+  return false;
 }
 
 uint8_t IRAM_ATTR addToSendQueue(uint8_t * buff, uint32_t length) {
@@ -51,19 +58,22 @@ void update_outputs() {
       outputs[i].update(&outputs[i]);
     }
   }
-  if(output_buffer_pos >0) {
-    // Send current buffer to all configured outputs
-    for(int i = 0; i < OUTPUT_SIZE; ++i) {
-      if(outputs[i].sendPacket) {
-        outputs[i].sendPacket(&outputs[i], output_buffer, output_buffer_pos);
+  if(xSemaphoreTake(queue_semaphore, portMAX_DELAY)) {
+    if(output_buffer_pos > 0) {
+      // Send current buffer to all configured outputs
+      for(int i = 0; i < OUTPUT_SIZE; ++i) {
+        if(outputs[i].sendPacket) {
+          outputs[i].sendPacket(&outputs[i], output_buffer, output_buffer_pos);
+        }
       }
+      output_buffer_pos = 0;
     }
-    // TODO: potential race condition? add mutex
-    output_buffer_pos = 0;
+    xSemaphoreGive(queue_semaphore);
   }
 }
 
 void init_outputs() {
+  queue_semaphore = xSemaphoreCreateMutex();
   for(int i = 0; i < OUTPUT_SIZE; ++i) {
     if(outputs[i].init) {
       outputs[i].init(&outputs[i]);


### PR DESCRIPTION
Handle the sending of laps on a different core to prevent lockups.

This should address the race condition, which could lead to a missed lap.
As locking can be tricky, I'd like to get a second opinion