### PR TITLE
Fix udp socket, when a client disconnects

### DIFF
--- a/ESP32LapTimer/UDP.cpp
+++ b/ESP32LapTimer/UDP.cpp
@@ -3,55 +3,85 @@
 #include "HardwareConfig.h"
 #include "Output.h"
 
-#include <WiFi.h>
-#include <WiFiUdp.h>
+#include <lwip/sockets.h>
+#include <lwip/netdb.h>
 
-static WiFiUDP UDPserver;
+static int udp_server = -1;
 
-static uint8_t packetBuffer[1500];
+#define UDP_BUF_LEN 1500
+static uint8_t packetBuffer[UDP_BUF_LEN];
 
 static struct udp_source_s {
-  IPAddress addr;
+  uint32_t addr;
   uint16_t port;
 } udpClients[MAX_UDP_CLIENTS];
 
-void add_ip_port() {
-  IPAddress remoteIp = UDPserver.remoteIP();
-  uint16_t port = UDPserver.remotePort();
+void add_ip_port(uint32_t addr, uint16_t port) {
   // if current ip is already known move it to the front. or if on the last entry delete it to make room
   for(int i = 0; i < MAX_UDP_CLIENTS; ++i) {
-    if((udpClients[i].addr == remoteIp && udpClients[i].port == port) || (i+1 == MAX_UDP_CLIENTS)) {
+    if((udpClients[i].addr == addr && udpClients[i].port == port) || (i+1 == MAX_UDP_CLIENTS)) {
       memmove(udpClients + 1, udpClients, i * sizeof(udpClients[0]));
       break;
     }
   }
-  udpClients[0].addr = remoteIp;
+  udpClients[0].addr = addr;
   udpClients[0].port = port;
 }
 
 void udp_init(void* output) {
-  UDPserver.begin(9000);
+  if ((udp_server=socket(AF_INET, SOCK_DGRAM, 0)) == -1){
+    return;
+  }
+
+  int yes = 1;
+  if (setsockopt(udp_server,SOL_SOCKET,SO_REUSEADDR,&yes,sizeof(yes)) < 0) {
+      close(udp_server);
+      udp_server = -1;
+      return;
+  }
+
+  struct sockaddr_in addr;
+  memset((char *) &addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(9000);
+  addr.sin_addr.s_addr = INADDR_ANY;
+  if(bind(udp_server , (struct sockaddr*)&addr, sizeof(addr)) == -1){
+    close(udp_server);
+    udp_server = -1;
+    return;
+  }
+  fcntl(udp_server, F_SETFL, O_NONBLOCK);  
 }
 
 void IRAM_ATTR udp_send_packet(void* output, uint8_t* buf, uint32_t size) {
+  if(udp_server < 0) return;
   if (buf != NULL && size != 0) {
     for(int i = 0; i < MAX_UDP_CLIENTS; ++i) {
       if(udpClients[i].addr != 0) {
-        UDPserver.beginPacket(udpClients[i].addr, udpClients[i].port);
-        UDPserver.write(buf, size);
-        UDPserver.endPacket();
+        struct sockaddr_in recipient;
+        recipient.sin_addr.s_addr = udpClients[i].addr;
+        recipient.sin_family = AF_INET;
+        recipient.sin_port = udpClients[i].port;
+        int len = sendto(udp_server, buf, size, 0, (struct sockaddr*) &recipient, sizeof(recipient));
+        if(len < 0) {
+          udpClients[i].addr = 0;
+          close(udp_server);
+          udp_init(output);
+        }
       }
     }
   }
 }
 
 void IRAM_ATTR udp_update(void* output) {
-  int packetSize = UDPserver.parsePacket();
-  if (packetSize > 0) {
-    add_ip_port();
-    int len = UDPserver.read(packetBuffer, 255);
-    if (len > 0) packetBuffer[len] = 0;
-    output_t* out = (output_t*)output;
-    out->handle_input_callback(packetBuffer, len);
+  if(udp_server < 0) return;
+  struct sockaddr_in si_other;
+  int slen = sizeof(si_other) , len;
+  if ((len = recvfrom(udp_server, packetBuffer, UDP_BUF_LEN - 1, MSG_DONTWAIT, (struct sockaddr *) &si_other, (socklen_t *)&slen)) < 1){
+    return;
   }
+  add_ip_port(si_other.sin_addr.s_addr, si_other.sin_port);
+  packetBuffer[len] = 0;
+  output_t* out = (output_t*)output;
+  out->handle_input_callback(packetBuffer, len);
 }


### PR DESCRIPTION
Whenever a client disconnects (e.g. just disables the WiFi), the socket would get an I/O error and fail on all following reads.
This bug existed since at least c49bcb4, so this might affect a bunch of users.

Additionally this uses the sockets directly to avoid ~3K of dynamically allocated memory (~1.5K every call to parsePacket(), so in every iteration of the main loop), which might also cause a bunch of problems.