### PR TITLE
Add support for display timeout

### DIFF
--- a/ESP32LapTimer/HardwareConfig.h
+++ b/ESP32LapTimer/HardwareConfig.h
@@ -15,7 +15,7 @@ void InitHardwarePins();
 
 // DO NOT CHANGE BELOW UNLESS USING CUSTOM HARDWARE
 
-#define EEPROM_VERSION_NUMBER 8 // Increment when eeprom struct modified
+#define EEPROM_VERSION_NUMBER 9 // Increment when eeprom struct modified
 
 #define WIFI_AP_NAME "Chorus32 LapTimer"
 #define BLUETOOTH_NAME WIFI_AP_NAME

--- a/ESP32LapTimer/WebServer.cpp
+++ b/ESP32LapTimer/WebServer.cpp
@@ -152,7 +152,7 @@ void SendStatusVars() {
 
 void SendStaticVars() {
 
-  String sendSTR = "{\"NumRXs\": " + String(getNumReceivers() - 1) + ", \"ADCVBATmode\": " + String(getADCVBATmode()) + ", \"RXFilter\": " + String(getRXADCfilter()) + ", \"ADCcalibValue\": " + String(getVBATcalibration(), 3) + ", \"RSSIthreshold\": " + String(getRSSIThreshold(0)) + ", \"WiFiChannel\": " + String(getWiFiChannel()) + ", \"WiFiProtocol\": " + String(getWiFiProtocol());;
+  String sendSTR = "{\"displayTimeout\": " + String(getDisplayTimeout()) + ", \"NumRXs\": " + String(getNumReceivers() - 1) + ", \"ADCVBATmode\": " + String(getADCVBATmode()) + ", \"RXFilter\": " + String(getRXADCfilter()) + ", \"ADCcalibValue\": " + String(getVBATcalibration(), 3) + ", \"RSSIthreshold\": " + String(getRSSIThreshold(0)) + ", \"WiFiChannel\": " + String(getWiFiChannel()) + ", \"WiFiProtocol\": " + String(getWiFiProtocol());;
   sendSTR = sendSTR + ",\"Band\":{";
   for (int i = 0; i < getNumReceivers(); i++) {
     sendSTR = sendSTR + "\"" + i + "\":" + EepromSettings.RXBand[i];
@@ -312,6 +312,14 @@ void ProcessWifiSettings() {
   airplaneModeOff();
 }
 
+void ProcessDisplaySettingsUpdate() {
+  EepromSettings.display_timeout_ms = webServer.arg("displayTimeout").toInt() * 1000;
+  File file = SPIFFS.open("/redirect.html", "r");                 // Open it
+  webServer.streamFile(file, "text/html"); // And send it to the client
+  file.close();
+  setSaveRequired();
+}
+
 void InitWebServer() {
 
 
@@ -367,6 +375,7 @@ void InitWebServer() {
   webServer.on("/updateGeneral", ProcessGeneralSettingsUpdate);
   webServer.on("/updateFilters", ProcessADCRXFilterUpdate);
   webServer.on("/ADCVBATsettings", ProcessVBATModeUpdate);
+  webServer.on("/displaySettings", ProcessDisplaySettingsUpdate);
   webServer.on("/calibrateRSSI",calibrateRSSI);
   webServer.on("/eepromReset",eepromReset);
   

--- a/ESP32LapTimer/data/GetStaticVars.js
+++ b/ESP32LapTimer/data/GetStaticVars.js
@@ -17,6 +17,7 @@
             document.getElementById('RSSIthreshold').value = updateRSSIThreshold(parseInt(data.RSSIthreshold))
             document.getElementById('WiFiProtocol').value = parseInt(data.WiFiProtocol);
             document.getElementById('WiFiChannel').value = parseInt(data.WiFiChannel);
+            document.getElementById('displayTimeout').value = parseInt(data.displayTimeout);
 
             createBandChannel(data.NumRXs)
             updateBandChannel(data)

--- a/ESP32LapTimer/data/index.html
+++ b/ESP32LapTimer/data/index.html
@@ -182,6 +182,17 @@
 						<input type="submit" value="&nbsp;Update&nbsp;">
 					</fieldset>
 				</form>
+				<form method="get" action="/displaySettings">
+					<fieldset>
+						<legend>
+							<h2><b>Display Settings</b></h2>
+						</legend>
+						Display timeout in seconds (0 to disable)<br>
+						<input type="int" name="displayTimeout" min="0" value="" id="displayTimeout">
+						<br><br>
+						<input type="submit" value="&nbsp;Update&nbsp;">
+					</fieldset>
+				</form>
 				<fieldset>
 					<legend>
 						<h2><b>Calibrate</b></h2>

--- a/ESP32LapTimer/settings_eeprom.cpp
+++ b/ESP32LapTimer/settings_eeprom.cpp
@@ -191,3 +191,7 @@ int getWiFiProtocol(){
 uint8_t getNumReceivers() {
   return EepromSettings.NumReceivers;
 }
+
+uint32_t getDisplayTimeout() {
+  return EepromSettings.display_timeout_ms;
+}

--- a/ESP32LapTimer/settings_eeprom.h
+++ b/ESP32LapTimer/settings_eeprom.h
@@ -31,6 +31,7 @@ struct EepromSettingsStruct {
   uint16_t RxCalibrationMax[MaxNumReceivers];
   uint8_t WiFiProtocol; // 0 is b only, 1 is bgn
   uint8_t WiFiChannel;
+  uint32_t display_timeout_ms;
   crc_t crc; // This MUST be the last variable!
 
 
@@ -56,5 +57,6 @@ int getWiFiChannel();
 int getWiFiProtocol();
 
 uint8_t getNumReceivers();
+uint32_t getDisplayTimeout();
 
 void setSaveRequired();


### PR DESCRIPTION
OLEDs tend to be very noisy (electrical and audible) when active. This adds a setting to enable an optional display timout after the last input (disabled by default).

I am not sure if it is the best to add yet another settings category to the webpage or if using an exsisting would be better?