### PR TITLE
Add support for (emergency) OTA mode

### DIFF
--- a/ESP32LapTimer/src/Buttons.cpp
+++ b/ESP32LapTimer/src/Buttons.cpp
@@ -8,6 +8,7 @@
 #include "Calibration.h"
 #include "settings_eeprom.h"
 #include "TimerWebServer.h"
+#include "CrashDetection.h"
 
 #include <stdint.h>
 #include <Arduino.h>
@@ -151,7 +152,7 @@ void newButtonUpdate() {
     fiveBeep();
     EepromSettings.defaults();
     delay(100);
-    ESP.restart();
+    restart_esp();
   }
 }
 

--- a/ESP32LapTimer/src/CrashDetection.cpp
+++ b/ESP32LapTimer/src/CrashDetection.cpp
@@ -1,0 +1,29 @@
+#include "CrashDetection.h"
+
+#include <rom/rtc.h>
+#include <Arduino.h>
+
+RTC_NOINIT_ATTR static int crash_count = 0;
+
+bool is_crash_mode() {
+  return crash_count > MAX_CRASH_COUNT;
+}
+
+void init_crash_detection() {
+  // crash reason is not sw reset, so not a crash!
+  if(rtc_get_reset_reason(0) != 12) {
+    crash_count = 0;
+  } else {
+    ++crash_count;
+  }
+}
+
+int get_crash_count() {
+  return crash_count;
+}
+
+
+void restart_esp() {
+  --crash_count;
+  ESP.restart();
+}

--- a/ESP32LapTimer/src/CrashDetection.cpp
+++ b/ESP32LapTimer/src/CrashDetection.cpp
@@ -3,10 +3,11 @@
 #include <rom/rtc.h>
 #include <Arduino.h>
 
+// positive values indicate a crashing system. negative values a manual reboot loop
 RTC_NOINIT_ATTR static int crash_count = 0;
 
 bool is_crash_mode() {
-  return (crash_count > MAX_CRASH_COUNT);
+  return (crash_count > MAX_CRASH_COUNT) || (crash_count > -MAX_CRASH_COUNT);
 }
 
 void init_crash_detection() {
@@ -22,7 +23,11 @@ int get_crash_count() {
   return crash_count;
 }
 
-void restart_esp() {
+void reset_crash_count() {
   crash_count = 0;
+}
+
+void restart_esp() {
+  --crash_count;
   ESP.restart();
 }

--- a/ESP32LapTimer/src/CrashDetection.cpp
+++ b/ESP32LapTimer/src/CrashDetection.cpp
@@ -6,7 +6,7 @@
 RTC_NOINIT_ATTR static int crash_count = 0;
 
 bool is_crash_mode() {
-  return crash_count > MAX_CRASH_COUNT;
+  return (crash_count > MAX_CRASH_COUNT);
 }
 
 void init_crash_detection() {
@@ -22,8 +22,7 @@ int get_crash_count() {
   return crash_count;
 }
 
-
 void restart_esp() {
-  --crash_count;
+  crash_count = 0;
   ESP.restart();
 }

--- a/ESP32LapTimer/src/CrashDetection.h
+++ b/ESP32LapTimer/src/CrashDetection.h
@@ -1,0 +1,11 @@
+#ifndef _CRASHDETECTION_H_
+#define _CRASHDETECTION_H_
+
+#define MAX_CRASH_COUNT 5
+
+bool is_crash_mode();
+void init_crash_detection();
+void restart_esp();
+int get_crash_count();
+
+#endif  // _CRASHDETECTION_H_

--- a/ESP32LapTimer/src/CrashDetection.h
+++ b/ESP32LapTimer/src/CrashDetection.h
@@ -7,5 +7,6 @@ bool is_crash_mode();
 void init_crash_detection();
 void restart_esp();
 int get_crash_count();
+void reset_crash_count();
 
 #endif  // _CRASHDETECTION_H_

--- a/ESP32LapTimer/src/ESP32LapTimer.cpp
+++ b/ESP32LapTimer/src/ESP32LapTimer.cpp
@@ -121,6 +121,9 @@ void loop() {
   ArduinoOTA.handle();
   if(is_crash_mode()) return;
 #endif
+  if(millis() > CRASH_COUNT_RESET_TIME_MS) {
+    reset_crash_count();
+  }
   rssiCalibrationUpdate();
   // touchMonitor(); // A function to monitor capacitive touch values, defined in buttons.ino
 

--- a/ESP32LapTimer/src/ESP32LapTimer.cpp
+++ b/ESP32LapTimer/src/ESP32LapTimer.cpp
@@ -24,6 +24,11 @@
 #include "Laptime.h"
 #include "Wireless.h"
 
+#include "CrashDetection.h"
+#ifdef USE_ARDUINO_OTA
+#include <ArduinoOTA.h>
+#endif
+
 //#define BluetoothEnabled //uncomment this to use bluetooth (experimental, ble + wifi appears to cause issues)
 
 static TaskHandle_t adc_task_handle = NULL;
@@ -47,13 +52,21 @@ void IRAM_ATTR adc_task(void* args) {
 }
 
 void setup() {
-
-#ifdef OLED
-  oledSetup();
-#endif
+  init_crash_detection();
 
   Serial.begin(115200);
   Serial.println("Booting....");
+#ifdef USE_ARDUINO_OTA
+  if(is_crash_mode()) {
+    log_e("Detected crashing. Starting ArduinoOTA only!");
+    InitWifiAP();
+    ArduinoOTA.begin();
+    return;
+  }
+#endif
+#ifdef OLED
+  oledSetup();
+#endif
 #ifdef USE_BUTTONS
   newButtonSetup();
 #endif
@@ -104,6 +117,10 @@ void setup() {
 }
 
 void loop() {
+#ifdef USE_ARDUINO_OTA
+  ArduinoOTA.handle();
+  if(is_crash_mode()) return;
+#endif
   rssiCalibrationUpdate();
   // touchMonitor(); // A function to monitor capacitive touch values, defined in buttons.ino
 

--- a/ESP32LapTimer/src/HardwareConfig.h
+++ b/ESP32LapTimer/src/HardwareConfig.h
@@ -42,6 +42,9 @@
 // Enable TCP support. Currently this needs a special version of the app: https://github.com/Smeat/Chorus-RF-Laptimer/releases/tag/tcp_support
 //#define USE_TCP
 
+// Enables the ArduinoOTA service. It allows flashing over WiFi and enters an emergency mode if a crashloop is detected.
+//#define USE_ARDUINO_OTA
+
 // BELOW ARE THE ADVANCED SETTINGS! ONLY CHANGE THEM IF YOU KNOW WHAT YOUR ARE DOING!
 
 #define EEPROM_VERSION_NUMBER 9 // Increment when eeprom struct modified
@@ -54,6 +57,8 @@
 // 800 and 2700 are about average min max raw values
 #define RSSI_ADC_READING_MAX 2700
 #define RSSI_ADC_READING_MIN 800
+// defines the time after which the crash loop detection assumes the operation is stable
+#define CRASH_COUNT_RESET_TIME_MS 300000
 
 #include "targets/target.h" // Needs to be at the bottom
 

--- a/ESP32LapTimer/src/TimerWebServer.cpp
+++ b/ESP32LapTimer/src/TimerWebServer.cpp
@@ -4,6 +4,7 @@
 #include "ADC.h"
 #include "RX5808.h"
 #include "Calibration.h"
+#include "CrashDetection.h"
 
 #include <esp_wifi.h>
 #include <FS.h>
@@ -278,7 +279,7 @@ void InitWebServer() {
     response->addHeader("Connection", "close");
     req->send(response);
     Serial.println("off-updating");
-    ESP.restart();
+    restart_esp();
   }, [](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
     isHTTPUpdating = true;
     if(!index) {


### PR DESCRIPTION
This adds the "Arduino OTA" functionality. It allows to flash a firmware over WiFi (without the webserver). Can be used directly by the Arduino IDE or in pio:
```
pio run -e BOARD_DEFAULT --target upload --upload-port 192.168.4.1
```

The crash detection enables only the bare minimum (including the OTA service) after the esp restarts/crashes 5 times.
This allows users without or hard to reach USB connectors to recover from a faulty firmware or configuration.

Disabled by default for now.