### PR TITLE
Force old version of espressif32

### DIFF
--- a/ESP32LapTimer/platformio.ini
+++ b/ESP32LapTimer/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env]
-platform = espressif32
+platform = espressif32 @ ~3.5.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200


### PR DESCRIPTION
The new version changes a bunch of things. Version 3.5.0 should work fine for now.

This should fix #127. @Z1gun can you confirm this fixes your issue?